### PR TITLE
Redis overview and key filtering, Kafka topic configs and multi-condition search

### DIFF
--- a/frontend/src/components/ObjectTree.tsx
+++ b/frontend/src/components/ObjectTree.tsx
@@ -29,8 +29,10 @@ import {
   DropdownMenuLabel,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { buildRedisTree, type RedisTreeNode } from '@/lib/redisTree'
+import { cn } from '@/lib/utils'
 import { normalizeVisibleSchemasSelection } from '@/lib/objectTreeVisibleSchemas'
-import { getObjectTypeLabel, isRedisNamespace } from '@/lib/objectTypes'
+import { getObjectTypeLabel } from '@/lib/objectTypes'
 import { useConnectionStore } from '@/stores/connections'
 import { useDataStore } from '@/stores/data'
 import { useToastStore } from '@/stores/toast'
@@ -186,6 +188,7 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
   const fetchTree = useWorkspaceStore((state) => state.fetchTree)
   const refreshTree = useWorkspaceStore((state) => state.refreshTree)
   const toggleSchema = useWorkspaceStore((state) => state.toggleSchema)
+  const scanMoreKeys = useWorkspaceStore((state) => state.scanMoreKeys)
   const setVisibleSchemas = useWorkspaceStore((state) => state.setVisibleSchemas)
   const openTab = useWorkspaceStore((state) => state.openTab)
   const ddl = useDataStore((state) => state.ddl)
@@ -203,6 +206,12 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
   const isKafkaConnection = currentConnection?.type === 'kafka'
   const rootKey = buildTreeKey(connId)
   const rootItems = useMemo(() => treeItems[rootKey] ?? [], [rootKey, treeItems])
+  // One flat page in, the whole hierarchy out. Rebuilt only when the page or the
+  // separator changes, so expanding a namespace never recomputes it.
+  const redisTree = useMemo(
+    () => buildRedisTree(rootItems, currentConnection?.separator || ':'),
+    [rootItems, currentConnection?.separator]
+  )
   const rootLoading = treeLoadingByKey[rootKey] ?? false
   const rootError = treeErrorByKey[rootKey] ?? null
   const rootLoaded = treeLoadedByKey[rootKey] ?? false
@@ -460,86 +469,62 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
   // buildTreeKey(connId) is the `${connId}::` prefix every level of this tree
   // shares, so startsWith identifies this connection's keys and the inequality
   // drops the root itself.
-  const namespaceNoticeVisible = Array.from(expandedSchemas).some(
-    (key) => key !== rootKey && key.startsWith(rootKey) && Boolean(treeCursors[key])
-  )
-
-  const renderRedisTruncatedNotice = (path = '') => {
-    const key = buildTreeKey(connId, path)
-    if (!treeCursors[key]) {
+  // The scan stops on a budget, not at the end of the keyspace, so a non-empty
+  // cursor means "there is more where this came from". Continuing appends to the
+  // tree rather than replacing it, so counts grow as the picture fills in.
+  const renderScanMore = () => {
+    if (!treeCursors[rootKey]) {
       return null
     }
-
-    // Under a filter the budget runs out on keys EXAMINED, not on keys shown, so
-    // a cut-short page can hold few matches or none. Saying "showing first ~1000
-    // keys" over an empty list would be plainly false, and it would read as "this
-    // pattern does not exist here" when the scan simply never got that far.
-    const filtered = Boolean(keyPattern)
-    const shown = (treeItems[key] ?? []).length
+    const scanning = treeLoadingByKey[rootKey] ?? false
 
     return (
-      <div className="mt-1 rounded-sm border border-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-[11px] text-amber-600 dark:text-amber-400">
-        {filtered
-          ? shown === 0
-            ? 'No matches yet — the scan stopped before covering the keyspace. Narrow the pattern, or use SCAN in the console.'
-            : 'Partial matches: the scan stopped before covering the keyspace. Narrow the pattern for the rest, or use SCAN in the console.'
-          : 'Showing first ~1000 keys. This prefix has more — query it in the console (SCAN/KEYS).'}
+      <div className="mt-2 space-y-1">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 w-full gap-1.5 font-mono text-[11px]"
+          disabled={scanning}
+          onClick={() => void scanMoreKeys(connId)}
+        >
+          <Search className={cn('h-3.5 w-3.5', scanning && 'animate-pulse')} />
+          {scanning ? 'Scanning…' : 'Scan more keys'}
+        </Button>
+        <div className="px-1 text-[11px] text-muted-foreground">
+          {formatCount(rootItems.length)} loaded{keyPattern ? ` matching ${keyPattern}` : ''} — the scan stopped on
+          its budget, not at the end of the keyspace.
+        </div>
       </div>
     )
   }
 
-  const renderRedisNamespaceNode = (item: ObjectItem) => {
-    const nodePath = item.path ?? item.name
-    const childKey = buildTreeKey(connId, nodePath)
+  const renderRedisNamespaceNode = (node: RedisTreeNode) => {
+    const childKey = buildTreeKey(connId, node.path)
     const expanded = expandedSchemas.has(childKey)
-    const children = treeItems[childKey] || []
-    const nodeLoading = expanded && Boolean(treeLoadingByKey[childKey])
-    const nodeError = expanded ? treeErrorByKey[childKey] : null
-    const nodeLoaded = treeLoadedByKey[childKey] ?? false
 
     return (
-      <div key={`namespace:${nodePath}`}>
+      <div key={`namespace:${node.path}`}>
         <button
           type="button"
-          onClick={() => handleNodeClick(nodePath)}
+          onClick={() => toggleSchema(connId, node.path)}
           className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
         >
           {getIcon('namespace', expanded)}
-          <span className="truncate">{item.name}</span>
+          <span className="truncate">{node.name}</span>
           <span className="ml-auto shrink-0 rounded-sm border border-red-500/20 bg-red-500/5 px-1.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.12em] text-red-500">
-            {formatCount(item.row_count)}{item.meta?.truncated ? '+' : ''} keys
+            {formatCount(node.keyCount)} keys
           </span>
         </button>
         {expanded && (
           <div className="ml-4 border-l border-border pl-1">
-            {nodeLoading && <LoadingSkeleton variant="tree" />}
-            {!nodeLoading && nodeError && (
-              <div className="mt-2">
-                <ErrorBanner message={nodeError} onRetry={() => void fetchTree(connId, nodePath)} />
-              </div>
-            )}
-            {!nodeLoading && !nodeError && nodeLoaded && children.length === 0 && (
-              <EmptyState
-                variant="no_tables"
-                compact
-                className="mt-2"
-                title="No keys in namespace"
-                description="This namespace currently has no loaded children."
-              />
-            )}
-            {!nodeLoading && !nodeError &&
-              children.map((child) =>
-                isRedisNamespace(child.type) ? renderRedisNamespaceNode(child) : renderRedisLeafItem(child)
-              )}
-            {!nodeLoading && !nodeError && renderRedisTruncatedNotice(nodePath)}
+            {node.namespaces.map(renderRedisNamespaceNode)}
+            {node.keys.map((child) => renderRedisLeafItem(child))}
           </div>
         )}
       </div>
     )
   }
-
-  const renderRedisItem = (item: ObjectItem) =>
-    isRedisNamespace(item.type) ? renderRedisNamespaceNode(item) : renderRedisLeafItem(item)
 
   const renderKafkaTopicItem = (item: ObjectItem) => {
     const partitions = typeof item.meta?.partitions === 'number' ? item.meta.partitions : 0
@@ -654,14 +639,17 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
   return (
     <>
       <div className="space-y-0.5">
-        {(isRedisConnection ? rootItems : filteredRootItems).map((item) =>
-          isRedisConnection ? renderRedisItem(item) : renderPgSchemaNode(item)
-        )}
+        {isRedisConnection
+          ? [
+              ...redisTree.namespaces.map(renderRedisNamespaceNode),
+              ...redisTree.keys.map((item) => renderRedisLeafItem(item)),
+            ]
+          : filteredRootItems.map((item) => renderPgSchemaNode(item))}
         {/* The root notice is suppressed while an open namespace is already
             showing the same sentence: two identical warnings a few rows apart
             read as two different problems. The namespace one is kept because it
             names which level is incomplete. */}
-        {isRedisConnection && !namespaceNoticeVisible && renderRedisTruncatedNotice()}
+        {isRedisConnection && renderScanMore()}
       </div>
       {!isRedisConnection && (
         <CreateTableForm

--- a/frontend/src/components/ObjectTree.tsx
+++ b/frontend/src/components/ObjectTree.tsx
@@ -175,6 +175,7 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
   const connections = useConnectionStore((state) => state.connections)
   const updateVisibleSchemas = useConnectionStore((state) => state.updateVisibleSchemas)
   const treeItems = useWorkspaceStore((state) => state.treeItems)
+  const keyPattern = useWorkspaceStore((state) => state.keyPatternByConnection[connId] ?? '')
   const treeCursors = useWorkspaceStore((state) => state.treeCursors)
   const treeLoadingByKey = useWorkspaceStore((state) => state.treeLoadingByKey)
   const treeErrorByKey = useWorkspaceStore((state) => state.treeErrorByKey)
@@ -462,9 +463,20 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
       return null
     }
 
+    // Under a filter the budget runs out on keys EXAMINED, not on keys shown, so
+    // a cut-short page can hold few matches or none. Saying "showing first ~1000
+    // keys" over an empty list would be plainly false, and it would read as "this
+    // pattern does not exist here" when the scan simply never got that far.
+    const filtered = Boolean(keyPattern)
+    const shown = (treeItems[key] ?? []).length
+
     return (
       <div className="mt-1 rounded-sm border border-amber-500/30 bg-amber-500/5 px-2 py-1.5 text-[11px] text-amber-600 dark:text-amber-400">
-        Showing first ~1000 keys. This prefix has more — query it in the console (SCAN/KEYS).
+        {filtered
+          ? shown === 0
+            ? 'No matches yet — the scan stopped before covering the keyspace. Narrow the pattern, or use SCAN in the console.'
+            : 'Partial matches: the scan stopped before covering the keyspace. Narrow the pattern for the rest, or use SCAN in the console.'
+          : 'Showing first ~1000 keys. This prefix has more — query it in the console (SCAN/KEYS).'}
       </div>
     )
   }

--- a/frontend/src/components/ObjectTree.tsx
+++ b/frontend/src/components/ObjectTree.tsx
@@ -457,6 +457,13 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
   // A non-empty cursor means the scan was cut short by the per-page budget, so
   // more keys exist than the single page we load. We never paginate further in
   // the tree: the user queries large prefixes from the console instead.
+  // buildTreeKey(connId) is the `${connId}::` prefix every level of this tree
+  // shares, so startsWith identifies this connection's keys and the inequality
+  // drops the root itself.
+  const namespaceNoticeVisible = Array.from(expandedSchemas).some(
+    (key) => key !== rootKey && key.startsWith(rootKey) && Boolean(treeCursors[key])
+  )
+
   const renderRedisTruncatedNotice = (path = '') => {
     const key = buildTreeKey(connId, path)
     if (!treeCursors[key]) {
@@ -650,7 +657,11 @@ export function ObjectTree({ connId, anchorConnId }: ObjectTreeProps) {
         {(isRedisConnection ? rootItems : filteredRootItems).map((item) =>
           isRedisConnection ? renderRedisItem(item) : renderPgSchemaNode(item)
         )}
-        {isRedisConnection && renderRedisTruncatedNotice()}
+        {/* The root notice is suppressed while an open namespace is already
+            showing the same sentence: two identical warnings a few rows apart
+            read as two different problems. The namespace one is kept because it
+            names which level is incomplete. */}
+        {isRedisConnection && !namespaceNoticeVisible && renderRedisTruncatedNotice()}
       </div>
       {!isRedisConnection && (
         <CreateTableForm

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Eye, Lock, PanelLeftClose, PanelLeft, Plus, RefreshCw, Settings, SlidersHorizontal, Table2, Zap } from 'lucide-react'
 import { CreateKeyDialog } from '@/components/redis/CreateKeyDialog'
 import { BulkActions } from '@/components/redis/BulkActions'
+import { RedisKeyFilter } from '@/components/redis/RedisKeyFilter'
 import { RedisKeyLookup } from '@/components/redis/RedisKeyLookup'
 import { EmptyState } from '@/components/EmptyState'
 import { LoadingSkeleton } from '@/components/LoadingSkeleton'
@@ -328,7 +329,12 @@ export function Sidebar({ connId }: SidebarProps) {
               </div>
             </div>
           )}
-          {currentConnection && isRedisConnection && <RedisKeyLookup connId={connId} />}
+          {currentConnection && isRedisConnection && (
+            <>
+              <RedisKeyLookup connId={connId} />
+              <RedisKeyFilter connId={connId} />
+            </>
+          )}
           {currentConnection && !isRedisConnection && !isKafkaConnection && (
             <TreeDatabaseSwitcher key={viewConnId} pageConnId={connId} viewConnId={viewConnId} />
           )}

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,4 +1,4 @@
-import { Activity, Braces, CircleDot, Database, Eye, Folder, Hash, List, ListOrdered, Plus, SquareTerminal, Table2, TerminalSquare, X, Zap } from 'lucide-react'
+import { Activity, Braces, CircleDot, Database, Eye, Folder, Gauge, Hash, List, ListOrdered, Plus, SquareTerminal, Table2, TerminalSquare, X, Zap } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useConnectionStore } from '@/stores/connections'
@@ -10,7 +10,10 @@ interface TabBarProps {
   connId: string
 }
 
-function tabIcon(kind: 'sql' | 'redis-cli' | ObjectType) {
+function tabIcon(kind: 'sql' | 'redis-cli' | 'overview' | ObjectType) {
+  if (kind === 'overview') {
+    return <Gauge className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+  }
   if (kind === 'sql') {
     return <SquareTerminal className="h-3.5 w-3.5 text-amber-500" />
   }
@@ -50,7 +53,8 @@ function tabIcon(kind: 'sql' | 'redis-cli' | ObjectType) {
 }
 
 export function TabBar({ connId }: TabBarProps) {
-  const { tabs, activeTabId, setActiveTab, closeTab, openSqlTab, openRedisCliTab } = useWorkspaceStore()
+  const { tabs, activeTabId, setActiveTab, closeTab, openSqlTab, openRedisCliTab, openOverviewTab } =
+    useWorkspaceStore()
   const connection = useConnectionStore((state) => state.connections.find((item) => item.id === connId))
   const isRedis = connection?.type === 'redis'
   const isKafka = connection?.type === 'kafka'
@@ -70,7 +74,15 @@ export function TabBar({ connId }: TabBarProps) {
                 : 'text-muted-foreground hover:bg-background/50 hover:text-foreground'
             )}
           >
-            {tabIcon(tab.kind === 'sql' ? 'sql' : tab.kind === 'redis-cli' ? 'redis-cli' : tab.objectType)}
+            {tabIcon(
+              tab.kind === 'sql'
+                ? 'sql'
+                : tab.kind === 'redis-cli'
+                  ? 'redis-cli'
+                  : tab.kind === 'overview'
+                    ? 'overview'
+                    : tab.objectType
+            )}
             <span className="max-w-[140px] truncate">{tab.label}</span>
             <button
               onClick={(e) => {
@@ -85,17 +97,30 @@ export function TabBar({ connId }: TabBarProps) {
         ))}
       </div>
       {isKafka ? null : isRedis ? (
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="h-8 shrink-0 gap-1.5 font-mono text-[11px]"
-          onClick={() => openRedisCliTab(connId)}
-          title="Open a new Redis CLI tab"
-        >
-          <Plus className="h-3.5 w-3.5" />
-          New CLI
-        </Button>
+        <>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 shrink-0 gap-1.5 font-mono text-[11px]"
+            onClick={() => openOverviewTab(connId)}
+            title="Show memory, limits and key count for this server"
+          >
+            <Gauge className="h-3.5 w-3.5" />
+            Overview
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 shrink-0 gap-1.5 font-mono text-[11px]"
+            onClick={() => openRedisCliTab(connId)}
+            title="Open a new Redis CLI tab"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            New CLI
+          </Button>
+        </>
       ) : (
         <Button
           type="button"

--- a/frontend/src/components/kafka/JsonFieldPickerDialog.tsx
+++ b/frontend/src/components/kafka/JsonFieldPickerDialog.tsx
@@ -194,6 +194,16 @@ export function JsonFieldPickerDialog({ open, onOpenChange, messages, onUseField
     onOpenChange(false)
   }
 
+  // Double-click uses the row it landed on rather than whatever was selected
+  // before it: the click that opens the second half of a double-click has
+  // already selected this node, but reading selectedPath here would race that
+  // state update.
+  const confirmNode = (node: SchemaNode) => {
+    selectNode(node)
+    onUseField(node.path)
+    onOpenChange(false)
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* min-w-0 is load-bearing, not cosmetic: DialogContent is a grid, and a
@@ -298,6 +308,7 @@ export function JsonFieldPickerDialog({ open, onOpenChange, messages, onUseField
                       onToggle={toggle}
                       onFocus={setFocusedPath}
                       onSelect={selectNode}
+                      onConfirm={confirmNode}
                     />
                   ))
                 )}

--- a/frontend/src/components/kafka/JsonFieldTreeNode.tsx
+++ b/frontend/src/components/kafka/JsonFieldTreeNode.tsx
@@ -12,6 +12,10 @@ interface JsonFieldTreeNodeProps {
   onToggle: (path: string) => void
   onFocus: (path: string) => void
   onSelect: (node: SchemaNode) => void
+  // Double-click confirms in one gesture: single-click already selects, so the
+  // trip to the Use field button is the only thing left between choosing a row
+  // and using it.
+  onConfirm: (node: SchemaNode) => void
 }
 
 // Type badge colours reuse the app's established data vocabulary (see
@@ -57,6 +61,7 @@ export function JsonFieldTreeNode({
   onToggle,
   onFocus,
   onSelect,
+  onConfirm,
 }: JsonFieldTreeNodeProps) {
   const isExpanded = expanded.has(node.path)
   const isFocused = focusedPath === node.path
@@ -85,6 +90,7 @@ export function JsonFieldTreeNode({
         aria-selected={isSelected}
         onMouseDown={() => onFocus(node.path)}
         onClick={primaryAction}
+        onDoubleClick={node.selectable ? () => onConfirm(node) : undefined}
         className={cn(
           fieldRowGrid,
           'rounded-sm py-1 pr-2 transition-colors',
@@ -158,6 +164,7 @@ export function JsonFieldTreeNode({
             expanded={expanded}
             focusedPath={focusedPath}
             selectedPath={selectedPath}
+            onConfirm={onConfirm}
             onToggle={onToggle}
             onFocus={onFocus}
             onSelect={onSelect}

--- a/frontend/src/components/kafka/KafkaFilterDialog.tsx
+++ b/frontend/src/components/kafka/KafkaFilterDialog.tsx
@@ -1,0 +1,159 @@
+import { ListTree, Plus, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
+import type { KafkaMatchCondition, KafkaMatchMode, KafkaMatchOp } from '@/stores/kafka'
+
+interface KafkaFilterDialogProps {
+  open: boolean
+  conditions: KafkaMatchCondition[]
+  mode: KafkaMatchMode
+  onOpenChange: (open: boolean) => void
+  onConditionsChange: (conditions: KafkaMatchCondition[]) => void
+  onModeChange: (mode: KafkaMatchMode) => void
+  // Opens the sampled-message field picker for one row.
+  onPickField: (index: number) => void
+}
+
+export const emptyCondition: KafkaMatchCondition = { field: '', value: '', op: 'eq' }
+
+export function KafkaFilterDialog({
+  open,
+  conditions,
+  mode,
+  onOpenChange,
+  onConditionsChange,
+  onModeChange,
+  onPickField,
+}: KafkaFilterDialogProps) {
+  const rows = conditions.length > 0 ? conditions : [emptyCondition]
+
+  const update = (index: number, patch: Partial<KafkaMatchCondition>) => {
+    onConditionsChange(rows.map((row, at) => (at === index ? { ...row, ...patch } : row)))
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl [&>*]:min-w-0">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">Message filters</DialogTitle>
+          <DialogDescription className="font-mono text-xs">
+            Each condition tests one JSON path in the message value. They apply both to the loaded messages and to a
+            topic scan.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Match</span>
+          {(['and', 'or'] as const).map((option) => (
+            <Button
+              key={option}
+              type="button"
+              size="sm"
+              variant={mode === option ? 'secondary' : 'outline'}
+              className="h-7 px-3 font-mono text-[11px]"
+              onClick={() => onModeChange(option)}
+              title={
+                option === 'and'
+                  ? 'A message must satisfy every condition'
+                  : 'A message must satisfy at least one condition'
+              }
+            >
+              {option === 'and' ? 'All conditions' : 'Any condition'}
+            </Button>
+          ))}
+        </div>
+
+        <div className="flex max-h-[50vh] flex-col gap-2 overflow-y-auto">
+          {rows.map((condition, index) => (
+            <div key={index} className="flex flex-wrap items-center gap-2">
+              <span className="w-8 shrink-0 font-mono text-[11px] text-muted-foreground">
+                {index === 0 ? '' : mode === 'or' ? 'or' : 'and'}
+              </span>
+              <input
+                value={condition.field}
+                onChange={(event) => update(index, { field: event.target.value })}
+                placeholder="JSON path (e.g. events[].name)"
+                aria-label={`JSON field path for condition ${index + 1}`}
+                spellCheck={false}
+                autoComplete="off"
+                className="h-8 w-56 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50"
+              />
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-8 w-8 shrink-0 p-0"
+                onClick={() => onPickField(index)}
+                title="Browse sampled messages and pick a field"
+                aria-label={`Choose field for condition ${index + 1}`}
+              >
+                <ListTree className="h-3.5 w-3.5" />
+              </Button>
+              <Select value={condition.op} onValueChange={(value) => update(index, { op: value as KafkaMatchOp })}>
+                <SelectTrigger className="h-8 w-32 font-mono text-xs" aria-label={`Match operator for condition ${index + 1}`}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="eq" className="font-mono text-xs">
+                    equals
+                  </SelectItem>
+                  <SelectItem value="exists" className="font-mono text-xs">
+                    has field
+                  </SelectItem>
+                  <SelectItem value="missing" className="font-mono text-xs">
+                    no field
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <input
+                value={condition.op === 'eq' ? condition.value : ''}
+                onChange={(event) => update(index, { value: event.target.value })}
+                placeholder={condition.op === 'eq' ? 'equals value' : 'not used'}
+                aria-label={`Expected value for condition ${index + 1}`}
+                disabled={condition.op !== 'eq'}
+                spellCheck={false}
+                autoComplete="off"
+                className="h-8 w-44 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+              />
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className={cn('h-8 w-8 shrink-0 p-0', rows.length === 1 && 'invisible')}
+                onClick={() => onConditionsChange(rows.filter((_, at) => at !== index))}
+                title="Remove this condition"
+                aria-label={`Remove condition ${index + 1}`}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 font-mono text-[11px]"
+            onClick={() => onConditionsChange([...rows, { ...emptyCondition }])}
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add condition
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            className="h-8 font-mono text-[11px]"
+            onClick={() => onOpenChange(false)}
+          >
+            Done
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/kafka/KafkaMessageBrowser.tsx
+++ b/frontend/src/components/kafka/KafkaMessageBrowser.tsx
@@ -1,9 +1,10 @@
 import { Fragment, useEffect, useMemo, useState, type FormEvent, type MouseEvent } from 'react'
-import { ChevronDown, ChevronRight, ChevronsDown, Filter, ListTree, Loader2, RefreshCw, Search, X } from 'lucide-react'
+import { ChevronDown, ChevronRight, ChevronsDown, Filter, Loader2, RefreshCw, Search, SlidersHorizontal, X } from 'lucide-react'
 import { KafkaFormatBadge } from '@/components/kafka/KafkaFormatBadge'
 import { KafkaMessageDetail } from '@/components/kafka/KafkaMessageDetail'
 import { KafkaMessageModal } from '@/components/kafka/KafkaMessageModal'
 import { JsonFieldPickerDialog } from '@/components/kafka/JsonFieldPickerDialog'
+import { KafkaFilterDialog, emptyCondition } from '@/components/kafka/KafkaFilterDialog'
 import { KafkaSeekControl } from '@/components/kafka/KafkaSeekControl'
 import { EmptyState } from '@/components/EmptyState'
 import {
@@ -23,7 +24,8 @@ import {
   filterLoadedMessages,
   MAX_SCAN_MATCHES,
   type KafkaDirection,
-  type KafkaMatchOp,
+  type KafkaMatchCondition,
+  type KafkaMatchMode,
   type KafkaMessageRow,
   type KafkaSeek,
 } from '@/stores/kafka'
@@ -39,14 +41,12 @@ interface KafkaMessageBrowserProps {
   partitionFilter: number | null
   // Filter loaded (client-side).
   filterActive: boolean
-  filterField: string
-  filterValue: string
-  filterOp: KafkaMatchOp
+  filterConditions: KafkaMatchCondition[]
+  filterMode: KafkaMatchMode
   // Search topic (backend scan).
   searchActive: boolean
-  searchField: string
-  searchValue: string
-  searchOp: KafkaMatchOp
+  searchConditions: KafkaMatchCondition[]
+  searchMode: KafkaMatchMode
   scanning: boolean
   scanned: number
   scanPartial: boolean
@@ -66,9 +66,9 @@ interface KafkaMessageBrowserProps {
   onDirectionChange: (direction: KafkaDirection) => void
   onRefresh: () => void
   onLoadOlder: () => void
-  onFilterLoaded: (field: string, value: string, op: KafkaMatchOp) => void
+  onFilterLoaded: (conditions: KafkaMatchCondition[], mode: KafkaMatchMode) => void
   onClearFilter: () => void
-  onSearchTopic: (field: string, value: string, op: KafkaMatchOp) => void
+  onSearchTopic: (conditions: KafkaMatchCondition[], mode: KafkaMatchMode) => void
   onScanMore: () => void
   onScanAll: () => void
   onCancelScanAll: () => void
@@ -106,13 +106,11 @@ export function KafkaMessageBrowser({
   partitionCount,
   partitionFilter,
   filterActive,
-  filterField,
-  filterValue,
-  filterOp,
+  filterConditions,
+  filterMode,
   searchActive,
-  searchField,
-  searchValue,
-  searchOp,
+  searchConditions,
+  searchMode,
   scanning,
   scanned,
   scanPartial,
@@ -148,11 +146,13 @@ export function KafkaMessageBrowser({
 }: KafkaMessageBrowserProps) {
   const [expanded, setExpanded] = useState<string | null>(null)
   const [modalMessage, setModalMessage] = useState<KafkaMessageRow | null>(null)
-  const [fieldInput, setFieldInput] = useState('')
-  const [valueInput, setValueInput] = useState('')
-  // 'exists'/'missing' ищут САМ ФАКТ наличия поля — единственный способ искать
-  // поле, значений которого ещё не знаешь (только раскатывается, например).
-  const [opInput, setOpInput] = useState<KafkaMatchOp>('eq')
+  // The draft the dialog edits. Applied only when Filter loaded or Search topic
+  // runs, so opening the dialog and closing it changes nothing on screen.
+  const [conditions, setConditions] = useState<KafkaMatchCondition[]>([{ ...emptyCondition }])
+  const [mode, setMode] = useState<KafkaMatchMode>('and')
+  const [filterDialogOpen, setFilterDialogOpen] = useState(false)
+  // Which condition the field picker is filling.
+  const [pickerIndex, setPickerIndex] = useState(0)
   const [menu, setMenu] = useState<{ x: number; y: number; message: KafkaMessageRow } | null>(null)
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -163,24 +163,23 @@ export function KafkaMessageBrowser({
     message: KafkaMessageRow | null
   } | null>(null)
 
-  // Seed the editable inputs when a search is set programmatically (e.g. a link
-  // jump populates the topic scan) so the user sees and can refine what's being
-  // searched. Guarded on a non-empty field so clearing a search never wipes what
+  // Seed the draft when a search is set programmatically (e.g. a link jump
+  // populates the topic scan) so the user sees and can refine what is being
+  // searched. Guarded on a non-empty set so clearing a search never wipes what
   // the user typed.
   useEffect(() => {
-    if (searchField) {
-      setFieldInput(searchField)
-      setValueInput(searchValue)
-      setOpInput(searchOp)
+    if (searchConditions.length > 0) {
+      setConditions(searchConditions)
+      setMode(searchMode)
     }
-  }, [searchField, searchValue, searchOp])
+  }, [searchConditions, searchMode])
 
   // The visible table rows: raw loaded messages, narrowed by the client-side
   // "Filter loaded" predicate when one is applied. During a topic search the
   // messages ARE the scan matches and no client filter applies.
   const visibleMessages = useMemo(
-    () => (filterActive ? filterLoadedMessages(messages, filterField, filterValue, filterOp) : messages),
-    [filterActive, filterField, filterValue, filterOp, messages]
+    () => (filterActive ? filterLoadedMessages(messages, filterConditions, filterMode) : messages),
+    [filterActive, filterConditions, filterMode, messages]
   )
 
   const linkPickerItems = useMemo<LinkPickerItem[]>(() => {
@@ -227,15 +226,16 @@ export function KafkaMessageBrowser({
     setMenu({ x: event.clientX, y: event.clientY, message })
   }
 
-  const canFilter = Boolean(fieldInput.trim()) && !searchActive && messages.length > 0
-  const canSearch = Boolean(fieldInput.trim()) && !scanning
+  const readyConditions = conditions.filter((condition) => condition.field.trim() !== '')
+  const canFilter = readyConditions.length > 0 && !searchActive && messages.length > 0
+  const canSearch = readyConditions.length > 0 && !scanning
 
   // Enter applies the cheap, instant client-side filter — never the expensive
   // topic scan, which stays an explicit, confirmed button click.
   const submitFilter = (event: FormEvent) => {
     event.preventDefault()
     if (!canFilter) return
-    onFilterLoaded(fieldInput, valueInput, opInput)
+    onFilterLoaded(readyConditions, mode)
   }
 
   return (
@@ -308,60 +308,23 @@ export function KafkaMessageBrowser({
       </div>
 
       <form onSubmit={submitFilter} className="flex flex-wrap items-center gap-2">
-        <input
-          value={fieldInput}
-          onChange={(event) => setFieldInput(event.target.value)}
-          placeholder="JSON path (e.g. events[].name)"
-          aria-label="JSON field path"
-          title="Nested paths and arrays are supported, for example events[].name"
-          spellCheck={false}
-          autoComplete="off"
-          className="h-8 w-56 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50"
-        />
         <Button
           type="button"
           size="sm"
           variant="outline"
           className="h-8 gap-1.5 font-mono text-[11px]"
-          onClick={() => setPickerOpen(true)}
-          title="Browse sampled messages and pick a field"
+          onClick={() => setFilterDialogOpen(true)}
+          title="Build the conditions a message must satisfy"
         >
-          <ListTree className="h-3.5 w-3.5" />
-          Choose field
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Filters
+          {readyConditions.length > 0 && (
+            <span className="rounded-sm border border-orange-500/30 bg-orange-500/5 px-1.5 text-[10px] uppercase tracking-[0.12em] text-orange-600 dark:text-orange-400">
+              {readyConditions.length}
+              {readyConditions.length > 1 ? ` ${mode}` : ''}
+            </span>
+          )}
         </Button>
-        {/* Same Select as the Partition control one row up, rather than a bare
-            <select>: the native one renders in the OS palette, so it was the
-            only light-on-white popup in a dark toolbar. */}
-        <Select value={opInput} onValueChange={(value) => setOpInput(value as KafkaMatchOp)}>
-          <SelectTrigger
-            className="h-8 w-32 font-mono text-xs"
-            aria-label="Match operator"
-            title="equals — compare the value. has field / no field — look for the field itself, at any depth."
-          >
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="eq" className="font-mono text-xs">
-              equals
-            </SelectItem>
-            <SelectItem value="exists" className="font-mono text-xs">
-              has field
-            </SelectItem>
-            <SelectItem value="missing" className="font-mono text-xs">
-              no field
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        <input
-          value={opInput === 'eq' ? valueInput : ''}
-          onChange={(event) => setValueInput(event.target.value)}
-          placeholder={opInput === 'eq' ? 'equals value' : 'not used'}
-          aria-label="Expected JSON field value"
-          disabled={opInput !== 'eq'}
-          spellCheck={false}
-          autoComplete="off"
-          className="h-8 w-44 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50"
-        />
         <Button
           type="submit"
           size="sm"
@@ -386,6 +349,19 @@ export function KafkaMessageBrowser({
           Search topic
         </Button>
       </form>
+
+      <KafkaFilterDialog
+        open={filterDialogOpen}
+        conditions={conditions}
+        mode={mode}
+        onOpenChange={setFilterDialogOpen}
+        onConditionsChange={setConditions}
+        onModeChange={setMode}
+        onPickField={(index) => {
+          setPickerIndex(index)
+          setPickerOpen(true)
+        }}
+      />
 
       {filterActive && (
         <div className="flex flex-wrap items-center gap-2 font-mono text-[11px] text-muted-foreground">
@@ -584,7 +560,11 @@ export function KafkaMessageBrowser({
         open={pickerOpen}
         onOpenChange={setPickerOpen}
         messages={messages}
-        onUseField={(path) => setFieldInput(path)}
+        onUseField={(path) =>
+          setConditions((current) =>
+            current.map((condition, at) => (at === pickerIndex ? { ...condition, field: path } : condition))
+          )
+        }
       />
 
       <LinkPickerDialog
@@ -728,7 +708,7 @@ export function KafkaMessageBrowser({
               size="sm"
               onClick={() => {
                 setConfirmOpen(false)
-                onSearchTopic(fieldInput, valueInput, opInput)
+                onSearchTopic(readyConditions, mode)
               }}
             >
               Search topic

--- a/frontend/src/components/kafka/KafkaTopicConfig.tsx
+++ b/frontend/src/components/kafka/KafkaTopicConfig.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { LoadingSkeleton } from '@/components/LoadingSkeleton'
+import { fetchWithTimeout } from '@/lib/http'
+import { describeRetentionSize, describeRetentionTime } from '@/lib/kafkaRetention'
+import { cn } from '@/lib/utils'
+
+interface KafkaTopicConfigProps {
+  connId: string
+  topic: string
+}
+
+interface TopicConfigEntry {
+  key: string
+  value: string
+  source: string
+  set_on_topic: boolean
+}
+
+interface TopicSchema {
+  meta?: {
+    partitions?: number
+    replication?: number
+    configs?: TopicConfigEntry[]
+  }
+}
+
+function headlineCard(label: string, value: string, note: string) {
+  return (
+    <div className="rounded-sm border border-border bg-muted/10 px-3 py-3">
+      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</div>
+      <div className="mt-2 font-mono text-sm">{value}</div>
+      <div className="mt-1 font-mono text-[11px] leading-relaxed text-muted-foreground">{note}</div>
+    </div>
+  )
+}
+
+export function KafkaTopicConfig({ connId, topic }: KafkaTopicConfigProps) {
+  const [schema, setSchema] = useState<TopicSchema | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchWithTimeout(
+        `/api/connections/${connId}/objects/${encodeURIComponent(topic)}/schema`
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error || 'Failed to load topic config')
+      }
+      setSchema((await res.json()) as TopicSchema)
+    } catch (loadError) {
+      setError((loadError as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [connId, topic])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (loading && !schema) {
+    return <LoadingSkeleton variant="table" />
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-3 font-mono text-xs text-destructive">
+        {error}
+      </div>
+    )
+  }
+
+  const partitions = schema?.meta?.partitions ?? 0
+  const configs = schema?.meta?.configs ?? []
+  const byKey = new Map(configs.map((config) => [config.key, config.value]))
+
+  const size = describeRetentionSize(byKey.get('retention.bytes'), partitions)
+  const time = describeRetentionTime(byKey.get('retention.ms'))
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        {headlineCard('Retention size', size.perPartition ?? 'None', size.note)}
+        {headlineCard('Retention time', time, 'Applies to the topic as a whole')}
+        {headlineCard(
+          'Partitions',
+          String(partitions),
+          size.topicTotal
+            ? `Each holds up to ${size.perPartition}`
+            : 'Retention size is enforced on each one separately'
+        )}
+      </div>
+
+      <div className="rounded-sm border border-border">
+        <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+          <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+            All configs ({configs.length})
+          </div>
+          {loading && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full font-mono text-xs">
+            <thead>
+              <tr className="border-b border-border text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                <th className="px-3 py-2 text-left font-normal">Key</th>
+                <th className="px-3 py-2 text-left font-normal">Value</th>
+                <th className="px-3 py-2 text-left font-normal">Set by</th>
+              </tr>
+            </thead>
+            <tbody>
+              {configs.map((config) => (
+                <tr key={config.key} className="border-b border-border/50 last:border-b-0">
+                  <td className="px-3 py-1.5 align-top">{config.key}</td>
+                  <td className="whitespace-pre-wrap break-all px-3 py-1.5 align-top">{config.value || '—'}</td>
+                  <td
+                    className={cn(
+                      'px-3 py-1.5 align-top',
+                      // An explicit topic-level value is the one somebody chose;
+                      // everything else is a default that can move under you.
+                      config.set_on_topic ? 'text-amber-600 dark:text-amber-400' : 'text-muted-foreground'
+                    )}
+                  >
+                    {config.source}
+                  </td>
+                </tr>
+              ))}
+              {configs.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-3 py-6 text-center text-muted-foreground">
+                    The broker reported no configs for this topic.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/kafka/KafkaTopicView.tsx
+++ b/frontend/src/components/kafka/KafkaTopicView.tsx
@@ -255,13 +255,11 @@ export function KafkaTopicView({ tabId, connId, topic }: KafkaTopicViewProps) {
             partitionCount={partitions.length}
             partitionFilter={tab?.partitionFilter ?? null}
             filterActive={tab?.filterActive ?? false}
-            filterField={tab?.filterField ?? ''}
-            filterValue={tab?.filterValue ?? ''}
-            filterOp={tab?.filterOp ?? 'eq'}
+            filterConditions={tab?.filterConditions ?? []}
+            filterMode={tab?.filterMode ?? 'and'}
             searchActive={tab?.searchActive ?? false}
-            searchField={tab?.searchField ?? ''}
-            searchValue={tab?.searchValue ?? ''}
-            searchOp={tab?.searchOp ?? 'eq'}
+            searchConditions={tab?.searchConditions ?? []}
+            searchMode={tab?.searchMode ?? 'and'}
             deepScanning={tab?.deepScanning ?? false}
             deepScanCanceled={tab?.deepScanCanceled ?? false}
             scanning={tab?.scanning ?? false}
@@ -277,9 +275,9 @@ export function KafkaTopicView({ tabId, connId, topic }: KafkaTopicViewProps) {
             onDirectionChange={(next) => void setDirection(connId, topic, tabId, next)}
             onRefresh={() => void refreshMessages(connId, topic, tabId)}
             onLoadOlder={() => void fetchOlderMessages(connId, topic, tabId)}
-            onFilterLoaded={(field, value, op) => setLoadedFilter(tabId, field, value, op)}
+            onFilterLoaded={(conditions, mode) => setLoadedFilter(tabId, conditions, mode)}
             onClearFilter={() => clearLoadedFilter(tabId)}
-            onSearchTopic={(field, value, op) => void searchTopic(connId, topic, tabId, field, value, op)}
+            onSearchTopic={(conditions, mode) => void searchTopic(connId, topic, tabId, conditions, mode)}
             onScanMore={() => void scanMore(connId, topic, tabId)}
             onScanAll={() => void scanAll(connId, topic, tabId)}
             onCancelScanAll={() => cancelScanAll(tabId)}

--- a/frontend/src/components/kafka/KafkaTopicView.tsx
+++ b/frontend/src/components/kafka/KafkaTopicView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Layers, Lock, MessagesSquare, RefreshCw, Send, Users } from 'lucide-react'
+import { Layers, Lock, MessagesSquare, RefreshCw, Send, SlidersHorizontal, Users } from 'lucide-react'
 import { KafkaConsumerGroups } from '@/components/kafka/KafkaConsumerGroups'
+import { KafkaTopicConfig } from '@/components/kafka/KafkaTopicConfig'
 import { KafkaMessageBrowser } from '@/components/kafka/KafkaMessageBrowser'
 import { KafkaPartitionsTable } from '@/components/kafka/KafkaPartitionsTable'
 import { KafkaProduceModal } from '@/components/kafka/KafkaProduceModal'
@@ -23,12 +24,13 @@ interface KafkaTopicViewProps {
   topic: string
 }
 
-type TopicTab = 'messages' | 'partitions' | 'groups'
+type TopicTab = 'messages' | 'partitions' | 'groups' | 'config'
 
 const tabs: Array<{ id: TopicTab; label: string; icon: typeof MessagesSquare }> = [
   { id: 'messages', label: 'Messages', icon: MessagesSquare },
   { id: 'partitions', label: 'Partitions', icon: Layers },
   { id: 'groups', label: 'Consumer Groups', icon: Users },
+  { id: 'config', label: 'Config', icon: SlidersHorizontal },
 ]
 
 export function KafkaTopicView({ tabId, connId, topic }: KafkaTopicViewProps) {
@@ -236,7 +238,10 @@ export function KafkaTopicView({ tabId, connId, topic }: KafkaTopicViewProps) {
           </div>
         </div>
 
-        {tab?.childrenError && activeTab !== 'messages' ? (
+        {/* Scoped to the tabs actually rendered from the children response:
+            Config loads its own schema, and a failed partition load reported
+            above the config table would blame the wrong request. */}
+        {tab?.childrenError && (activeTab === 'partitions' || activeTab === 'groups') ? (
           <ErrorBanner message={tab.childrenError} onRetry={() => void fetchTopicChildren(connId, topic, tabId)} />
         ) : null}
 
@@ -305,6 +310,8 @@ export function KafkaTopicView({ tabId, connId, topic }: KafkaTopicViewProps) {
           ) : (
             <KafkaConsumerGroups groups={groups} />
           ))}
+
+        {activeTab === 'config' && <KafkaTopicConfig connId={connId} topic={topic} />}
       </div>
 
       <KafkaProduceModal

--- a/frontend/src/components/redis/RedisKeyFilter.tsx
+++ b/frontend/src/components/redis/RedisKeyFilter.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { Filter, X } from 'lucide-react'
+import { useWorkspaceStore } from '@/stores/workspace'
+
+interface RedisKeyFilterProps {
+  connId: string
+}
+
+// Debounce before a keystroke turns into a keyspace SCAN. Long enough that
+// typing a prefix does not fire a scan per character, short enough that the
+// tree still feels like it is reacting to the input.
+const FILTER_DEBOUNCE_MS = 350
+
+// Narrows the Redis tree to keys matching a glob. Unlike RedisKeyLookup, which
+// opens one exact key, this filters every level of the tree at once: the
+// pattern is applied by SCAN MATCH on the server, so it finds keys that were
+// never loaded rather than filtering the rows already on screen.
+export function RedisKeyFilter({ connId }: RedisKeyFilterProps) {
+  const pattern = useWorkspaceStore((state) => state.keyPatternByConnection[connId] ?? '')
+  const setKeyPattern = useWorkspaceStore((state) => state.setKeyPattern)
+  const [draft, setDraft] = useState(pattern)
+
+  // Follow the store when the pattern changes elsewhere — switching connections
+  // reuses this component, and its draft would otherwise show the old value.
+  useEffect(() => {
+    setDraft(pattern)
+  }, [connId, pattern])
+
+  useEffect(() => {
+    if (draft === pattern) {
+      return
+    }
+    const timer = setTimeout(() => void setKeyPattern(connId, draft.trim()), FILTER_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [draft, pattern, connId, setKeyPattern])
+
+  return (
+    <div className="relative mb-2">
+      <Filter className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+      <input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            void setKeyPattern(connId, draft.trim())
+          }
+          if (event.key === 'Escape' && draft) {
+            event.preventDefault()
+            setDraft('')
+          }
+        }}
+        placeholder="Filter keys, e.g. session:*"
+        spellCheck={false}
+        autoComplete="off"
+        aria-label="Filter Redis keys by pattern"
+        className="h-8 w-full rounded-sm border border-border bg-background pl-7 pr-7 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-amber-500/50"
+      />
+      {draft && (
+        <button
+          type="button"
+          onClick={() => setDraft('')}
+          title="Clear filter"
+          aria-label="Clear key filter"
+          className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded-sm p-0.5 text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/redis/RedisKeyLookup.tsx
+++ b/frontend/src/components/redis/RedisKeyLookup.tsx
@@ -52,6 +52,25 @@ export function RedisKeyLookup({ connId }: RedisKeyLookupProps) {
               setError(null)
             }
           }}
+          onPaste={(event) => {
+            // Selecting a key with the mouse picks up the whitespace the grid's
+            // markup puts between cells, so a paste after a typed prefix lands
+            // as "profile: 1234" and matches nothing. Trimming on submit is too
+            // late — by then the space is in the middle of the key.
+            const pasted = event.clipboardData.getData('text').trim()
+            if (!pasted) {
+              return
+            }
+            event.preventDefault()
+            const input = event.currentTarget
+            // setRangeText replaces the selection and leaves the caret after the
+            // inserted text, the way a native paste would.
+            input.setRangeText(pasted, input.selectionStart ?? 0, input.selectionEnd ?? 0, 'end')
+            setValue(input.value)
+            if (error) {
+              setError(null)
+            }
+          }}
           placeholder="Open key by name…"
           spellCheck={false}
           autoComplete="off"

--- a/frontend/src/components/redis/RedisOverview.tsx
+++ b/frontend/src/components/redis/RedisOverview.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from 'react'
+import { AlertTriangle, Database, Loader2, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { fetchWithTimeout } from '@/lib/http'
+import { formatBytes, formatDurationSeconds, formatExactCount } from '@/lib/numberFormat'
+import { cn } from '@/lib/utils'
+import { useConnectionStore } from '@/stores/connections'
+import type { ConnectionInfo } from '@/types/api'
+
+interface RedisOverviewProps {
+  connId: string
+}
+
+// INFO reports every field as a string; a missing field and an unparseable one
+// are the same thing here — a number we do not have and must not invent.
+function num(extra: Record<string, unknown> | undefined, key: string): number | null {
+  const raw = extra?.[key]
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null
+  if (typeof raw !== 'string' || raw === '') return null
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function str(extra: Record<string, unknown> | undefined, key: string): string | null {
+  const raw = extra?.[key]
+  return typeof raw === 'string' && raw !== '' ? raw : null
+}
+
+function statCard(label: string, value: string, hint?: string) {
+  return (
+    <div className="rounded-sm border border-border bg-muted/10 px-3 py-3">
+      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</div>
+      <div className="mt-2 font-mono text-sm">{value}</div>
+      {hint && <div className="mt-1 font-mono text-[11px] text-muted-foreground">{hint}</div>}
+    </div>
+  )
+}
+
+// The meter is drawn only against a real ceiling. maxmemory 0 means Redis is not
+// enforcing one at all, and a bar sitting at 0% would read as "plenty of room"
+// for a server that will in fact keep growing until the host runs out.
+function MemoryMeter({ used, max }: { used: number; max: number }) {
+  const ratio = Math.min(used / max, 1)
+  const percent = ratio * 100
+  const level = percent >= 90 ? 'critical' : percent >= 75 ? 'warning' : 'normal'
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="font-mono text-sm">
+          {formatBytes(used)} <span className="text-muted-foreground">of {formatBytes(max)}</span>
+        </div>
+        <div className="flex items-center gap-2 font-mono text-sm">
+          {level !== 'normal' && (
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-sm border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em]',
+                level === 'critical'
+                  ? 'border-red-500/30 bg-red-500/5 text-red-600 dark:text-red-400'
+                  : 'border-orange-500/30 bg-orange-500/5 text-orange-600 dark:text-orange-400'
+              )}
+            >
+              <AlertTriangle className="h-3 w-3" />
+              {level === 'critical' ? 'Near limit' : 'Filling up'}
+            </span>
+          )}
+          {percent.toFixed(1)}%
+        </div>
+      </div>
+      <div
+        className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        role="meter"
+        aria-valuenow={Math.round(percent)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Memory used against the configured limit"
+      >
+        <div
+          className={cn(
+            'h-full rounded-full transition-[width]',
+            level === 'critical' ? 'bg-red-500' : level === 'warning' ? 'bg-orange-500' : 'bg-amber-500'
+          )}
+          style={{ width: `${Math.max(ratio * 100, ratio > 0 ? 1 : 0)}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function RedisOverview({ connId }: RedisOverviewProps) {
+  const connection = useConnectionStore((state) => state.connections.find((item) => item.id === connId))
+  const [info, setInfo] = useState<ConnectionInfo | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchWithTimeout(`/api/connections/${connId}/info`)
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error || 'Failed to load connection info')
+      }
+      setInfo((await res.json()) as ConnectionInfo)
+    } catch (loadError) {
+      setError((loadError as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [connId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const extra = info?.extra
+  const used = num(extra, 'used_memory')
+  const max = num(extra, 'maxmemory')
+  const peak = num(extra, 'used_memory_peak')
+  const rss = num(extra, 'used_memory_rss')
+  const policy = str(extra, 'maxmemory_policy')
+  const totalKeys = num(extra, 'total_keys')
+  const uptime = num(extra, 'uptime_in_seconds')
+  const clients = num(extra, 'connected_clients')
+  const fragmentation = num(extra, 'mem_fragmentation_ratio')
+  const role = str(extra, 'role')
+  const mode = str(extra, 'mode')
+
+  return (
+    <div className="flex-1 overflow-auto p-4">
+      <div className="mx-auto flex max-w-4xl flex-col gap-3">
+        <div className="rounded-sm border border-border bg-card p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-sm border border-red-500/30 bg-red-500/5">
+                <Database className="h-5 w-5 text-red-500" />
+              </div>
+              <div className="min-w-0">
+                <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Redis overview</div>
+                <div className="mt-1 truncate font-mono text-lg">{connection?.name ?? connId}</div>
+                <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                  {[mode, info?.version && `v${info.version}`, role].filter(Boolean).map((badge) => (
+                    <span
+                      key={badge as string}
+                      className="inline-flex items-center rounded-sm border border-border px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+                    >
+                      {badge}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 shrink-0 gap-1.5 font-mono text-[11px]"
+              disabled={loading}
+              onClick={() => void load()}
+            >
+              <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+              Refresh
+            </Button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-3 font-mono text-xs text-destructive">
+            {error}
+          </div>
+        )}
+
+        {loading && !info && (
+          <div className="flex items-center gap-2 rounded-sm border border-border bg-muted/10 px-3 py-6 font-mono text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Reading server info…
+          </div>
+        )}
+
+        {info && (
+          <>
+            <div className="rounded-sm border border-border bg-card p-4">
+              <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Memory</div>
+              <div className="mt-3">
+                {used === null ? (
+                  <div className="font-mono text-xs text-muted-foreground">
+                    This server did not report its memory use.
+                  </div>
+                ) : max !== null && max > 0 ? (
+                  <MemoryMeter used={used} max={max} />
+                ) : (
+                  <div>
+                    <div className="font-mono text-sm">{formatBytes(used)} used</div>
+                    <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+                      No maxmemory limit is set — this server grows until the host runs out, and evicts nothing on
+                      its own.
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {statCard('Policy', policy ?? '—', policy === 'noeviction' ? 'Writes fail at the limit' : undefined)}
+                {statCard('Peak', peak === null ? '—' : formatBytes(peak))}
+                {statCard('RSS', rss === null ? '—' : formatBytes(rss))}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+              {statCard(
+                'Total keys',
+                totalKeys === null ? '—' : formatExactCount(totalKeys),
+                totalKeys === null ? 'Not counted' : mode === 'cluster' ? 'Summed across masters' : undefined
+              )}
+              {statCard('Uptime', uptime === null ? '—' : formatDurationSeconds(uptime))}
+              {statCard('Clients', clients === null ? '—' : formatExactCount(clients))}
+              {statCard(
+                'Fragmentation',
+                fragmentation === null ? '—' : fragmentation.toFixed(2),
+                fragmentation !== null && fragmentation > 1.5 ? 'More RSS than data' : undefined
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/redis/RedisOverview.tsx
+++ b/frontend/src/components/redis/RedisOverview.tsx
@@ -126,6 +126,13 @@ export function RedisOverview({ connId }: RedisOverviewProps) {
   const fragmentation = num(extra, 'mem_fragmentation_ratio')
   const role = str(extra, 'role')
   const mode = str(extra, 'mode')
+  const nodes = num(extra, 'node_count') ?? 1
+  const nodeUsed = num(extra, 'node_used_memory')
+  const nodeMax = num(extra, 'node_maxmemory')
+  // Everything below the headline is a cluster total. Said plainly, because the
+  // same screen used to show one node's 20 GiB of 30 GiB as though it were the
+  // whole cluster's — which on 24 masters understated it twenty-four fold.
+  const clusterNote = nodes > 1 ? `Summed across ${nodes} masters` : undefined
 
   return (
     <div className="flex-1 overflow-auto p-4">
@@ -188,7 +195,17 @@ export function RedisOverview({ connId }: RedisOverviewProps) {
                     This server did not report its memory use.
                   </div>
                 ) : max !== null && max > 0 ? (
-                  <MemoryMeter used={used} max={max} />
+                  <>
+                    <MemoryMeter used={used} max={max} />
+                    {nodes > 1 && (
+                      <div className="mt-2 font-mono text-[11px] text-muted-foreground">
+                        Across {nodes} masters
+                        {nodeUsed !== null && nodeMax !== null
+                          ? ` — ${formatBytes(nodeUsed)} of ${formatBytes(nodeMax)} on each`
+                          : ''}
+                      </div>
+                    )}
+                  </>
                 ) : (
                   <div>
                     <div className="font-mono text-sm">{formatBytes(used)} used</div>
@@ -201,8 +218,8 @@ export function RedisOverview({ connId }: RedisOverviewProps) {
               </div>
               <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3">
                 {statCard('Policy', policy ?? '—', policy === 'noeviction' ? 'Writes fail at the limit' : undefined)}
-                {statCard('Peak', peak === null ? '—' : formatBytes(peak))}
-                {statCard('RSS', rss === null ? '—' : formatBytes(rss))}
+                {statCard('Peak', peak === null ? '—' : formatBytes(peak), clusterNote)}
+                {statCard('RSS', rss === null ? '—' : formatBytes(rss), clusterNote)}
               </div>
             </div>
 
@@ -210,10 +227,14 @@ export function RedisOverview({ connId }: RedisOverviewProps) {
               {statCard(
                 'Total keys',
                 totalKeys === null ? '—' : formatExactCount(totalKeys),
-                totalKeys === null ? 'Not counted' : mode === 'cluster' ? 'Summed across masters' : undefined
+                totalKeys === null ? 'Not counted' : clusterNote
               )}
-              {statCard('Uptime', uptime === null ? '—' : formatDurationSeconds(uptime))}
-              {statCard('Clients', clients === null ? '—' : formatExactCount(clients))}
+              {statCard(
+                'Uptime',
+                uptime === null ? '—' : formatDurationSeconds(uptime),
+                nodes > 1 ? 'On the node that answered' : undefined
+              )}
+              {statCard('Clients', clients === null ? '—' : formatExactCount(clients), clusterNote)}
               {statCard(
                 'Fragmentation',
                 fragmentation === null ? '—' : fragmentation.toFixed(2),

--- a/frontend/src/hooks/useOpenLink.ts
+++ b/frontend/src/hooks/useOpenLink.ts
@@ -82,7 +82,9 @@ function useOpenLinkEnd(resolve: (link: LinkRecord) => LinkEndpoint) {
 
       openTab(end.connId, end.scope, 'kafka_topic')
       go()
-      void searchTopic(end.connId, end.scope, `${end.connId}:kafka_topic:${end.scope}`, end.field, value)
+      void searchTopic(end.connId, end.scope, `${end.connId}:kafka_topic:${end.scope}`, [
+        { field: end.field, value, op: 'eq' },
+      ])
     },
     [resolve, navigate, openTab, openTabWithFilter, openConnection, resolveObjectType, searchTopic, pushToast]
   )

--- a/frontend/src/lib/kafkaRetention.test.ts
+++ b/frontend/src/lib/kafkaRetention.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { describeRetentionSize, describeRetentionTime } from '@/lib/kafkaRetention'
+
+describe('describeRetentionSize', () => {
+  // The case this exists for: a limit that reads as a topic-wide 233 GiB but
+  // actually bounds each of the 12 partitions separately.
+  it('multiplies the per-partition limit by the partition count', () => {
+    const result = describeRetentionSize('250000000000', 12)
+    expect(result.perPartition).toBe('232.83 GiB')
+    expect(result.topicTotal).toBe('2.73 TiB')
+    expect(result.note).toContain('12 partitions')
+  })
+
+  it('keeps the singular for a one-partition topic', () => {
+    expect(describeRetentionSize('1073741824', 1).note).toContain('Across 1 partition the')
+  })
+
+  it('reports -1 as no size limit rather than a negative one', () => {
+    const result = describeRetentionSize('-1', 12)
+    expect(result.perPartition).toBeNull()
+    expect(result.topicTotal).toBeNull()
+    expect(result.note).toContain('No size limit')
+  })
+
+  it('withholds the total when the partition count is unknown', () => {
+    const result = describeRetentionSize('250000000000', 0)
+    expect(result.perPartition).toBe('232.83 GiB')
+    expect(result.topicTotal).toBeNull()
+  })
+
+  it('reports a missing config as missing, not as unlimited', () => {
+    expect(describeRetentionSize(undefined, 12).note).toBe('Not reported by the broker')
+  })
+})
+
+describe('describeRetentionTime', () => {
+  it('renders the Kafka default of seven days', () => {
+    expect(describeRetentionTime('604800000')).toBe('7d 0h')
+  })
+
+  it('reports -1 as infinite retention', () => {
+    expect(describeRetentionTime('-1')).toContain('Kept forever')
+  })
+
+  it('distinguishes zero from unlimited', () => {
+    expect(describeRetentionTime('0')).toBe('Deleted immediately')
+  })
+
+  it('reports a missing config as missing', () => {
+    expect(describeRetentionTime(undefined)).toBe('Not reported by the broker')
+  })
+})

--- a/frontend/src/lib/kafkaRetention.ts
+++ b/frontend/src/lib/kafkaRetention.ts
@@ -1,0 +1,65 @@
+import { formatBytes, formatDurationSeconds } from '@/lib/numberFormat'
+
+// Kafka enforces retention.bytes per partition, not per topic. Reading it as a
+// topic-wide ceiling understates the real one by a factor of the partition
+// count — a 250 GB limit on a 12-partition topic bounds it at ~2.7 TiB, not
+// 233 GiB. Both numbers are rendered so the per-partition value can never be
+// mistaken for the topic's total.
+export interface RetentionSize {
+  // Per-partition limit as configured, or null when the topic has no size limit.
+  perPartition: string | null
+  // Per-partition limit multiplied by the partition count. Null when there is
+  // no limit, or when the partition count is unknown and the product would be
+  // a guess.
+  topicTotal: string | null
+  note: string
+}
+
+// Kafka spells "no limit" as -1 for both retention configs.
+const UNLIMITED = -1
+
+function parseConfig(value: string | undefined): number | null {
+  if (value === undefined || value === '') return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+export function describeRetentionSize(value: string | undefined, partitions: number): RetentionSize {
+  const bytes = parseConfig(value)
+
+  if (bytes === null) {
+    return { perPartition: null, topicTotal: null, note: 'Not reported by the broker' }
+  }
+  if (bytes < 0) {
+    return {
+      perPartition: null,
+      topicTotal: null,
+      note: 'No size limit — this topic is trimmed by time alone',
+    }
+  }
+  if (!Number.isInteger(partitions) || partitions < 1) {
+    return {
+      perPartition: formatBytes(bytes),
+      topicTotal: null,
+      note: 'Per partition — the topic-wide ceiling needs the partition count',
+    }
+  }
+
+  return {
+    perPartition: formatBytes(bytes),
+    topicTotal: formatBytes(bytes * partitions),
+    note: `Per partition. Across ${partitions} partition${partitions === 1 ? '' : 's'} the topic can hold ${formatBytes(
+      bytes * partitions
+    )}.`,
+  }
+}
+
+// retention.ms is a topic-wide age limit, so unlike retention.bytes it means
+// exactly what it reads as.
+export function describeRetentionTime(value: string | undefined): string {
+  const ms = parseConfig(value)
+  if (ms === null) return 'Not reported by the broker'
+  if (ms === UNLIMITED || ms < 0) return 'Kept forever — no time limit'
+  if (ms === 0) return 'Deleted immediately'
+  return formatDurationSeconds(ms / 1000)
+}

--- a/frontend/src/lib/numberFormat.test.ts
+++ b/frontend/src/lib/numberFormat.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { formatCompactCount, formatExactCount, splitSharedPrefix } from '@/lib/numberFormat'
+import {
+  formatBytes,
+  formatCompactCount,
+  formatDurationSeconds,
+  formatExactCount,
+  splitSharedPrefix,
+} from '@/lib/numberFormat'
 
 describe('formatCompactCount', () => {
   const cases: Array<{ name: string; value: number; want: string }> = [
@@ -43,5 +49,39 @@ describe('splitSharedPrefix', () => {
   it('highlights everything when the values are equal', () => {
     // A caught-up partition has no differing part to point at.
     expect(splitSharedPrefix('500', '500')).toEqual({ prefix: '', rest: '500' })
+  })
+})
+
+describe('formatBytes', () => {
+  const cases: Array<{ name: string; value: number; want: string }> = [
+    { name: 'zero', value: 0, want: '0 B' },
+    { name: 'plain bytes carry no fraction', value: 512, want: '512 B' },
+    { name: 'kibibytes', value: 2048, want: '2.00 KiB' },
+    // The retention.bytes from the topic that started this: read as GiB, not GB.
+    { name: 'a topic retention limit', value: 250000000000, want: '232.83 GiB' },
+    { name: 'terabytes', value: 3 * 1024 ** 4, want: '3.00 TiB' },
+    { name: 'not a number', value: Number.NaN, want: '\u2014' },
+  ]
+
+  cases.forEach(({ name, value, want }) => {
+    it(name, () => {
+      expect(formatBytes(value)).toBe(want)
+    })
+  })
+})
+
+describe('formatDurationSeconds', () => {
+  const cases: Array<{ name: string; value: number; want: string }> = [
+    { name: 'seconds', value: 45, want: '45s' },
+    { name: 'minutes', value: 305, want: '5m 5s' },
+    { name: 'hours', value: 7500, want: '2h 5m' },
+    { name: 'days drop everything below hours', value: 1043400, want: '12d 1h' },
+    { name: 'negative is not a duration', value: -1, want: '\u2014' },
+  ]
+
+  cases.forEach(({ name, value, want }) => {
+    it(name, () => {
+      expect(formatDurationSeconds(value)).toBe(want)
+    })
   })
 })

--- a/frontend/src/lib/numberFormat.ts
+++ b/frontend/src/lib/numberFormat.ts
@@ -65,3 +65,44 @@ export function splitSharedPrefix(value: string, other: string): SharedPrefixSpl
   }
   return { prefix: value.slice(0, shared), rest: value.slice(shared) }
 }
+
+const BYTE_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'] as const
+
+// formatBytes renders a byte count in binary units: 250000000000 -> "232.83 GiB".
+//
+// Binary rather than decimal because that is what the servers report: Redis
+// INFO's used_memory and Kafka's retention.bytes are both counted in bytes and
+// conventionally read as GiB, and rendering 250000000000 as "250 GB" next to a
+// server that calls it 232 GiB invites exactly the mismatch this screen exists
+// to prevent.
+export function formatBytes(value: number): string {
+  if (!Number.isFinite(value)) return '—'
+  const negative = value < 0
+  let size = Math.abs(value)
+  let unit = 0
+  while (size >= 1024 && unit < BYTE_UNITS.length - 1) {
+    size /= 1024
+    unit += 1
+  }
+  // Whole bytes never get a fraction; larger units keep two digits, enough to
+  // tell 232.83 GiB from 232.91 GiB without implying byte-level precision.
+  const rendered = unit === 0 ? String(Math.round(size)) : size.toFixed(2)
+  return `${negative ? '-' : ''}${rendered} ${BYTE_UNITS[unit]}`
+}
+
+// formatDurationSeconds renders an elapsed time at the two coarsest units that
+// carry information: 1043400 -> "12d 1h". Uptime is read to answer "was this
+// restarted recently", so seconds stop mattering once there are hours.
+export function formatDurationSeconds(value: number): string {
+  if (!Number.isFinite(value) || value < 0) return '—'
+  const total = Math.floor(value)
+  const days = Math.floor(total / 86400)
+  const hours = Math.floor((total % 86400) / 3600)
+  const minutes = Math.floor((total % 3600) / 60)
+  const seconds = total % 60
+
+  if (days > 0) return `${days}d ${hours}h`
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}

--- a/frontend/src/lib/redisTree.test.ts
+++ b/frontend/src/lib/redisTree.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { buildRedisTree } from '@/lib/redisTree'
+import type { ObjectItem } from '@/types/api'
+
+const key = (path: string): ObjectItem =>
+  ({ name: path, path, type: 'redis_string', row_count: 0 }) as unknown as ObjectItem
+
+describe('buildRedisTree', () => {
+  it('groups by the separator and counts every key beneath a namespace', () => {
+    const tree = buildRedisTree([key('profile:1'), key('profile:2'), key('session:9')], ':')
+
+    expect(tree.namespaces.map((n) => n.name)).toEqual(['profile', 'session'])
+    expect(tree.namespaces[0].keyCount).toBe(2)
+    expect(tree.namespaces[0].keys.map((k) => k.name)).toEqual(['1', '2'])
+    expect(tree.keyCount).toBe(3)
+  })
+
+  it('nests deeper levels', () => {
+    const tree = buildRedisTree([key('a:b:c'), key('a:b:d'), key('a:e')], ':')
+
+    const a = tree.namespaces[0]
+    expect(a.path).toBe('a')
+    expect(a.keys.map((k) => k.name)).toEqual(['e'])
+    const b = a.namespaces[0]
+    expect(b.path).toBe('a:b')
+    expect(b.keys.map((k) => k.name)).toEqual(['c', 'd'])
+    expect(a.keyCount).toBe(3)
+  })
+
+  it('keeps a key with no separator at the root', () => {
+    const tree = buildRedisTree([key('lonely'), key('ns:one')], ':')
+
+    expect(tree.keys.map((k) => k.name)).toEqual(['lonely'])
+    expect(tree.namespaces.map((n) => n.name)).toEqual(['ns'])
+  })
+
+  // "a:b:" is a real key whose last segment is empty. It belongs under a:b, and
+  // it falls back to its full name rather than rendering as a blank row.
+  it('keeps a key whose last segment is empty, under its namespace', () => {
+    const tree = buildRedisTree([key('a:b:')], ':')
+
+    const b = tree.namespaces[0].namespaces[0]
+    expect(b.path).toBe('a:b')
+    expect(b.keys.map((k) => k.name)).toEqual(['a:b:'])
+  })
+
+  // An empty segment in the middle ("a::b") must not become a nameless folder
+  // that cannot be told apart from its neighbours.
+  it('stops descending at an empty middle segment', () => {
+    const tree = buildRedisTree([key('a::b')], ':')
+
+    const a = tree.namespaces[0]
+    expect(a.namespaces).toEqual([])
+    // Inside folder "a" what is left of the key is ":b" — the same rule that
+    // renders "profile:1" as "1".
+    expect(a.keys.map((k) => k.name)).toEqual([':b'])
+  })
+
+  it('counts a namespace by its keys, not by its sub-namespaces', () => {
+    const tree = buildRedisTree([key('x:1'), key('x:y:2'), key('x:y:3')], ':')
+
+    expect(tree.namespaces[0].keyCount).toBe(3)
+    expect(tree.namespaces[0].namespaces[0].keyCount).toBe(2)
+  })
+})

--- a/frontend/src/lib/redisTree.ts
+++ b/frontend/src/lib/redisTree.ts
@@ -1,0 +1,71 @@
+import type { ObjectItem } from '@/types/api'
+
+// One level of the Redis key tree. The whole tree is derived from a single flat
+// page of keys, so a namespace is not something the server listed — it is the
+// shared prefix of the keys the client already holds. That makes expanding a
+// folder free, and makes its count the number of keys actually behind it rather
+// than the result of a second scan with its own budget.
+export interface RedisTreeNode {
+  // Segment shown on the row, e.g. "profile" for the namespace or "1998…" for a
+  // key sitting inside one.
+  name: string
+  // Full prefix this node stands for, e.g. "profile" or "a:b". Empty at the root.
+  path: string
+  namespaces: RedisTreeNode[]
+  // Keys that end at this level, in the order the page delivered them.
+  keys: ObjectItem[]
+  // Keys anywhere below this node, its own included.
+  keyCount: number
+}
+
+function emptyNode(name: string, path: string): RedisTreeNode {
+  return { name, path, namespaces: [], keys: [], keyCount: 0 }
+}
+
+// buildRedisTree groups keys by separator, one segment per level, so
+// "profile:1998:x" nests under "profile" then "1998". A key whose name ends in
+// the separator ("a:b:") has a trailing empty segment; it is kept as a leaf of
+// the last non-empty level rather than creating a nameless folder.
+export function buildRedisTree(items: ObjectItem[], separator: string): RedisTreeNode {
+  const root = emptyNode('', '')
+  if (separator === '') {
+    root.keys = [...items]
+    root.keyCount = items.length
+    return root
+  }
+
+  for (const item of items) {
+    const fullKey = item.path ?? item.name
+    const segments = fullKey.split(separator)
+    let node = root
+    node.keyCount += 1
+
+    // The last segment is the key itself; everything before it is a namespace.
+    for (let depth = 0; depth < segments.length - 1; depth += 1) {
+      const segment = segments[depth]
+      if (segment === '') {
+        break
+      }
+      const path = node.path === '' ? segment : `${node.path}${separator}${segment}`
+      let child = node.namespaces.find((candidate) => candidate.path === path)
+      if (!child) {
+        child = emptyNode(segment, path)
+        node.namespaces.push(child)
+      }
+      child.keyCount += 1
+      node = child
+    }
+
+    const leafName = node.path === '' ? fullKey : fullKey.slice(node.path.length + separator.length)
+    node.keys.push({ ...item, name: leafName === '' ? fullKey : leafName })
+  }
+
+  sortNode(root)
+  return root
+}
+
+function sortNode(node: RedisTreeNode) {
+  node.namespaces.sort((a, b) => a.name.localeCompare(b.name))
+  node.keys.sort((a, b) => a.name.localeCompare(b.name))
+  node.namespaces.forEach(sortNode)
+}

--- a/frontend/src/lib/workspacePersistence.ts
+++ b/frontend/src/lib/workspacePersistence.ts
@@ -85,6 +85,7 @@ function isWorkspaceTab(value: unknown): value is WorkspaceTab {
   switch (value.kind) {
     case 'sql':
     case 'redis-cli':
+    case 'overview':
       return true
     case 'object':
       return (

--- a/frontend/src/pages/ConnectionListPage.tsx
+++ b/frontend/src/pages/ConnectionListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTheme } from 'next-themes'
 import { Plus, Sun, Moon, Settings } from 'lucide-react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -12,7 +12,7 @@ import { EmptyState } from '@/components/EmptyState'
 import { ErrorBanner } from '@/components/ErrorBanner'
 import { LoadingSkeleton } from '@/components/LoadingSkeleton'
 import type { Connection } from '@/types/api'
-import { useConnectionHealthStore } from '@/stores/connectionHealth'
+import { HEALTH_POLL_MS, useConnectionHealthStore } from '@/stores/connectionHealth'
 
 export default function ConnectionListPage() {
   const navigate = useNavigate()
@@ -53,6 +53,10 @@ export default function ConnectionListPage() {
     void fetchConnections()
   }, [connections.length, error, fetchConnections, loadedOnce, loading])
 
+  // Stable across re-renders so the poll below is not torn down and restarted
+  // every time this component renders for an unrelated reason.
+  const connectionIds = useMemo(() => connections.map((connection) => connection.id), [connections])
+
   // Pruning is gated on the fetch having actually succeeded, not merely having
   // finished: the store sets loadedOnce on its error path too (see
   // stores/connections.ts), leaving connections at []. Without this, one
@@ -61,16 +65,57 @@ export default function ConnectionListPage() {
   // on its own, so this is the second half of the same guard, placed here
   // because only the caller knows whether the list is trustworthy.
   useEffect(() => {
-    if (!loadedOnce || error) {
-      return
-    }
-    const connectionIds = connections.map((connection) => connection.id)
-    if (connectionIds.length === 0) {
+    if (!loadedOnce || error || connectionIds.length === 0) {
       return
     }
     pruneHealth(connectionIds)
     void refreshStaleHealth(connectionIds)
-  }, [connections, error, loadedOnce, pruneHealth, refreshStaleHealth])
+  }, [connectionIds, error, loadedOnce, pruneHealth, refreshStaleHealth])
+
+  // Health only re-checks itself while this screen is open and its tab is in the
+  // foreground. Without the tick, a status had exactly one chance to be right --
+  // the moment the list mounted -- so a server that came back (VPN reconnected,
+  // datasource restarted) stayed red until the user pressed test by hand.
+  //
+  // Scoped rather than global on purpose: dialing every datasource on a minute's
+  // schedule while the user is working inside one database is load nobody asked
+  // for. The tick is also TTL-gated by refreshStale, so a burst of remounts or a
+  // tab regaining focus cannot turn into a burst of connection tests.
+  useEffect(() => {
+    if (!loadedOnce || error || connectionIds.length === 0) {
+      return
+    }
+
+    let timer: number | undefined
+    const tick = () => {
+      if (document.hidden) {
+        return
+      }
+      void refreshStaleHealth(connectionIds)
+    }
+    const start = () => {
+      window.clearInterval(timer)
+      timer = window.setInterval(tick, HEALTH_POLL_MS)
+    }
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        // Stop the timer outright instead of letting it fire into a hidden tab:
+        // browsers throttle background intervals unpredictably, and a resumed
+        // tab should re-check immediately rather than wait out a stale phase.
+        window.clearInterval(timer)
+        return
+      }
+      tick()
+      start()
+    }
+
+    start()
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => {
+      window.clearInterval(timer)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [connectionIds, error, loadedOnce, refreshStaleHealth])
 
   const openCreate = () => {
     setEditingConnection(undefined)

--- a/frontend/src/pages/ConnectionListPage.tsx
+++ b/frontend/src/pages/ConnectionListPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTheme } from 'next-themes'
 import { Plus, Sun, Moon, Settings } from 'lucide-react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -57,6 +57,11 @@ export default function ConnectionListPage() {
   // every time this component renders for an unrelated reason.
   const connectionIds = useMemo(() => connections.map((connection) => connection.id), [connections])
 
+  // Spent once per mount, not on every run of the effect below: the connection
+  // list changes identity whenever it is refetched, and those must not re-test
+  // every datasource.
+  const forcedThisMount = useRef(false)
+
   // Pruning is gated on the fetch having actually succeeded, not merely having
   // finished: the store sets loadedOnce on its error path too (see
   // stores/connections.ts), leaving connections at []. Without this, one
@@ -64,12 +69,20 @@ export default function ConnectionListPage() {
   // persists, drop it from localStorage as well. The store refuses an empty list
   // on its own, so this is the second half of the same guard, placed here
   // because only the caller knows whether the list is trustworthy.
+  //
+  // Opening this screen — a reload, or coming back from a database — is the user
+  // asking whether these are up right now, so the first pass forces past the
+  // TTL. Reusing the cached answer there made a reload look ignored: the status
+  // could not change however many times it was pressed, and only the per-card
+  // test button did anything.
   useEffect(() => {
     if (!loadedOnce || error || connectionIds.length === 0) {
       return
     }
     pruneHealth(connectionIds)
-    void refreshStaleHealth(connectionIds)
+    const force = !forcedThisMount.current
+    forcedThisMount.current = true
+    void refreshStaleHealth(connectionIds, { force })
   }, [connectionIds, error, loadedOnce, pruneHealth, refreshStaleHealth])
 
   // Health only re-checks itself while this screen is open and its tab is in the

--- a/frontend/src/pages/DataViewPage.tsx
+++ b/frontend/src/pages/DataViewPage.tsx
@@ -13,6 +13,7 @@ import { IndexInspectorView } from '@/components/IndexInspectorView'
 import { PgTableView } from '@/components/PgTableView'
 import { SqlConsole } from '@/components/SqlConsole/SqlConsole'
 import { RedisCli } from '@/components/redis/RedisCli/RedisCli'
+import { RedisOverview } from '@/components/redis/RedisOverview'
 import { KafkaTopicView } from '@/components/kafka/KafkaTopicView'
 import { isRedisObjectType } from '@/lib/objectTypes'
 import { isConnectionHealthStale, useConnectionHealthStore } from '@/stores/connectionHealth'
@@ -132,6 +133,8 @@ export default function DataViewPage() {
                 <SqlConsole tabId={activeTab.id} connId={activeTab.connId} />
               ) : activeTab.kind === 'redis-cli' ? (
                 <RedisCli tabId={activeTab.id} connId={activeTab.connId} />
+              ) : activeTab.kind === 'overview' ? (
+                <RedisOverview connId={activeTab.connId} />
               ) : activeTab.objectType === 'index' ? (
                 <IndexInspectorView
                   connId={activeTab.connId}

--- a/frontend/src/stores/connectionHealth.ts
+++ b/frontend/src/stores/connectionHealth.ts
@@ -17,7 +17,7 @@ interface ConnectionHealthStore {
   hydrate: () => void
   prune: (ids: string[]) => void
   refresh: (id: string, options?: { force?: boolean }) => Promise<ConnectionHealthEntry>
-  refreshStale: (ids: string[]) => Promise<void>
+  refreshStale: (ids: string[], options?: { force?: boolean }) => Promise<void>
 }
 
 const STORAGE_KEY = 'kizuna-connection-health'
@@ -206,10 +206,20 @@ export const useConnectionHealthStore = create<ConnectionHealthStore>((set, get)
     return request
   },
 
-  refreshStale: async (ids: string[]) => {
+  // force re-tests everything regardless of how recently it was checked. It is
+  // what opening or reloading the list means: the user is asking, now, whether
+  // these are up. Without it a reload inside the TTL window returned the cached
+  // answer and looked like the page had simply ignored the reload.
+  //
+  // The cached entry is still rendered while the re-test runs, so a forced pass
+  // revalidates in the background instead of blanking the cards.
+  refreshStale: async (ids: string[], options?: { force?: boolean }) => {
     const stale = ids.filter((id) => {
       const entry = get().entries[id]
-      return !isFresh(entry) && !entry?.checking
+      if (entry?.checking) {
+        return false
+      }
+      return options?.force === true || !isFresh(entry)
     })
 
     let cursor = 0
@@ -218,7 +228,7 @@ export const useConnectionHealthStore = create<ConnectionHealthStore>((set, get)
       while (cursor < stale.length) {
         const id = stale[cursor++]
         try {
-          await get().refresh(id)
+          await get().refresh(id, { force: options?.force })
         } catch {
           // Keep background refresh best-effort. The card will render the error state.
         }

--- a/frontend/src/stores/connectionHealth.ts
+++ b/frontend/src/stores/connectionHealth.ts
@@ -21,7 +21,14 @@ interface ConnectionHealthStore {
 }
 
 const STORAGE_KEY = 'kizuna-connection-health'
-const HEALTH_TTL_MS = 60_000
+export const HEALTH_TTL_MS = 60_000
+
+// How often the connection list re-examines its entries. Deliberately shorter
+// than the TTL: a tick only turns into real network checks for entries that have
+// crossed HEALTH_TTL_MS, so the cost stays one round of checks per minute, but
+// polling at exactly the TTL would let a tick land just before an entry expires
+// and leave the status stale for close to two minutes.
+export const HEALTH_POLL_MS = HEALTH_TTL_MS / 2
 // Cap concurrent health checks so a large connection list refreshes fast without
 // dialing every datasource at once. Each check is bounded by fetchWithTimeout on
 // the client and dial/ping deadlines on the server, so workers never hang.

--- a/frontend/src/stores/kafka.network.test.ts
+++ b/frontend/src/stores/kafka.network.test.ts
@@ -37,15 +37,15 @@ describe('Filter loaded — client-side only', () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    useKafkaStore.getState().setLoadedFilter('tab-filter', 'src.event_data.events[].name', 'Auth')
+    useKafkaStore.getState().setLoadedFilter('tab-filter', [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }])
     let tab = useKafkaStore.getState().tabs['tab-filter']
     expect(tab.filterActive).toBe(true)
-    expect(tab.filterField).toBe('src.event_data.events[].name')
+    expect(tab.filterConditions[0].field).toBe('src.event_data.events[].name')
 
     useKafkaStore.getState().clearLoadedFilter('tab-filter')
     tab = useKafkaStore.getState().tabs['tab-filter']
     expect(tab.filterActive).toBe(false)
-    expect(tab.filterField).toBe('')
+    expect(tab.filterConditions).toEqual([])
 
     // The whole point of "Filter loaded": zero requests, and the cursor state
     // (nextCursor/hasMore) is never mutated by filtering.
@@ -69,7 +69,7 @@ describe('Search topic — backend scan', () => {
     )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-scan', 'src.event_data.events[].name', 'Auth')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-scan', [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }])
 
     const tab = useKafkaStore.getState().tabs['tab-scan']
     expect(tab.searchActive).toBe(true)
@@ -106,7 +106,7 @@ describe('Search topic — backend scan', () => {
       )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-more', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-more', [{ field: 'a.b', value: 'x', op: 'eq' }])
     await useKafkaStore.getState().scanMore('c1', 'topic', 'tab-more')
 
     const tab = useKafkaStore.getState().tabs['tab-more']
@@ -138,7 +138,7 @@ describe('Search topic — backend scan', () => {
     )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-partial', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-partial', [{ field: 'a.b', value: 'x', op: 'eq' }])
 
     const tab = useKafkaStore.getState().tabs['tab-partial']
     expect(tab.scanPartial).toBe(true)
@@ -174,7 +174,7 @@ describe('Cancel aborts the in-flight request', () => {
       )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-cancel', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-cancel', [{ field: 'a.b', value: 'x', op: 'eq' }])
     expect(useKafkaStore.getState().tabs['tab-cancel'].messages).toHaveLength(1)
 
     // Kick off a second step but don't await it — it hangs on the mock above.
@@ -232,12 +232,12 @@ describe('Cancel aborts the in-flight request', () => {
       )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-stale', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-stale', [{ field: 'a.b', value: 'x', op: 'eq' }])
     const stale = useKafkaStore.getState().scanMore('c1', 'topic', 'tab-stale')
     await Promise.resolve()
 
     useKafkaStore.getState().cancelScan('tab-stale')
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-stale', 'a.b', 'y')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-stale', [{ field: 'a.b', value: 'y', op: 'eq' }])
 
     const afterReplacement = useKafkaStore.getState().tabs['tab-stale']
     expect(afterReplacement.messages).toHaveLength(1)
@@ -292,7 +292,7 @@ describe('Search all — ceiling on accumulated matches', () => {
     })
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-cap', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-cap', [{ field: 'a.b', value: 'x', op: 'eq' }])
     expect(useKafkaStore.getState().tabs['tab-cap'].messages).toHaveLength(3000)
     expect(useKafkaStore.getState().tabs['tab-cap'].scanLimitReached).toBe(false)
 
@@ -325,7 +325,7 @@ describe('Search all — ceiling on accumulated matches', () => {
     )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-exact', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-exact', [{ field: 'a.b', value: 'x', op: 'eq' }])
 
     const tab = useKafkaStore.getState().tabs['tab-exact']
     expect(tab.messages).toHaveLength(MAX_SCAN_MATCHES)
@@ -347,7 +347,7 @@ describe('Search all — ceiling on accumulated matches', () => {
     )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-exact-more', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-exact-more', [{ field: 'a.b', value: 'x', op: 'eq' }])
 
     const tab = useKafkaStore.getState().tabs['tab-exact-more']
     expect(tab.messages).toHaveLength(MAX_SCAN_MATCHES)
@@ -376,7 +376,7 @@ describe('Search all — ceiling on accumulated matches', () => {
     )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-reset', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-reset', [{ field: 'a.b', value: 'x', op: 'eq' }])
 
     expect(useKafkaStore.getState().tabs['tab-reset'].scanLimitReached).toBe(false)
   })
@@ -397,7 +397,7 @@ describe('loadInitialMessages — mount-path guard against search clobbering', (
       )
     )
     vi.stubGlobal('fetch', searchFetch as unknown as typeof fetch)
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-remount', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-remount', [{ field: 'a.b', value: 'x', op: 'eq' }])
 
     const afterSearch = useKafkaStore.getState().tabs['tab-remount']
     expect(afterSearch.searchActive).toBe(true)
@@ -491,7 +491,7 @@ describe('Refresh is search-aware (settled-search clobber guard)', () => {
       )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-refresh-search', 'src.event_data.events[].name', 'Auth')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-refresh-search', [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }])
 
     const settled = useKafkaStore.getState().tabs['tab-refresh-search']
     expect(settled.searchActive).toBe(true)
@@ -575,7 +575,7 @@ describe('Clearing a search returns to browse', () => {
       )
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-clear', 'a.b', 'x')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-clear', [{ field: 'a.b', value: 'x', op: 'eq' }])
     await useKafkaStore.getState().clearSearch('c1', 'topic', 'tab-clear')
 
     const tab = useKafkaStore.getState().tabs['tab-clear']
@@ -684,8 +684,8 @@ describe('Seek — browse anchor', () => {
         'tab-seek': {
           ...useKafkaStore.getState().tabs['tab-seek'],
           searchActive: true,
-          searchField: 'src.event_data.events[].name',
-          searchValue: 'Auth',
+          searchConditions: [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }],
+          searchMode: 'and',
           messages: [scanRow(0, 9)],
         },
       },
@@ -876,7 +876,7 @@ describe('scanAll — автоцикл до начала лога', () => {
       .mockResolvedValueOnce(scanPage(3000, [900], false, 0))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-all', 'Metadata', '', 'exists')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-all', [{ field: 'Metadata', value: '', op: 'exists' }])
     await useKafkaStore.getState().scanAll('c1', 'topic', 'tab-all')
 
     const tab = useKafkaStore.getState().tabs['tab-all']
@@ -900,7 +900,7 @@ describe('scanAll — автоцикл до начала лога', () => {
     })
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-cancel', 'Metadata', '', 'exists')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-cancel', [{ field: 'Metadata', value: '', op: 'exists' }])
     await useKafkaStore.getState().scanAll('c1', 'topic', 'tab-cancel')
 
     const tab = useKafkaStore.getState().tabs['tab-cancel']
@@ -917,7 +917,7 @@ describe('scanAll — автоцикл до начала лога', () => {
     const fetchMock = vi.fn(() => Promise.resolve(scanPage(10, [], true, 777)))
     vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
 
-    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-stuck', 'Metadata', '', 'exists')
+    await useKafkaStore.getState().searchTopic('c1', 'topic', 'tab-stuck', [{ field: 'Metadata', value: '', op: 'exists' }])
     await useKafkaStore.getState().scanAll('c1', 'topic', 'tab-stuck')
 
     // Первый запрос — сам поиск, дальше ровно один шаг цикла, который не сдвинул

--- a/frontend/src/stores/kafka.test.ts
+++ b/frontend/src/stores/kafka.test.ts
@@ -15,24 +15,24 @@ const viewOnlyDoc = '{"src":{"event_data":{"events":[{"name":"View"}]}}}'
 describe('filterLoadedMessages', () => {
   it('returns the input unchanged for an empty path (no filtering)', () => {
     const messages = [row(0, 1, authDoc), row(0, 2, viewOnlyDoc)]
-    expect(filterLoadedMessages(messages, '', 'anything')).toBe(messages)
-    expect(filterLoadedMessages(messages, '   ', 'anything')).toBe(messages)
+    expect(filterLoadedMessages(messages, [{ field: '', value: 'anything', op: 'eq' }])).toBe(messages)
+    expect(filterLoadedMessages(messages, [{ field: '   ', value: 'anything', op: 'eq' }])).toBe(messages)
   })
 
   it('keeps only rows whose nested-array leaf equals the value (docs/msg.json fixture)', () => {
     const messages = [row(0, 1, authDoc), row(1, 5, viewOnlyDoc), row(2, 9, authDoc)]
-    const matches = filterLoadedMessages(messages, 'src.event_data.events[].name', 'Auth')
+    const matches = filterLoadedMessages(messages, [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }])
     expect(matches.map((m) => `${m.partition}:${m.offset}`)).toEqual(['0:1', '2:9'])
   })
 
   it('returns no rows when nothing matches the value', () => {
     const messages = [row(0, 1, authDoc), row(0, 2, viewOnlyDoc)]
-    expect(filterLoadedMessages(messages, 'src.event_data.events[].name', 'Nope')).toEqual([])
+    expect(filterLoadedMessages(messages, [{ field: 'src.event_data.events[].name', value: 'Nope', op: 'eq' }])).toEqual([])
   })
 
   it('excludes non-JSON rows (they never match a non-empty path)', () => {
     const messages = [row(0, 1, authDoc), row(0, 2, 'not json at all', 'text')]
-    const matches = filterLoadedMessages(messages, 'src.event_data.events[].name', 'Auth')
+    const matches = filterLoadedMessages(messages, [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }])
     expect(matches).toHaveLength(1)
     expect(matches[0].offset).toBe(1)
   })
@@ -40,14 +40,39 @@ describe('filterLoadedMessages', () => {
   it('does not mutate the input array', () => {
     const messages = [row(0, 1, authDoc), row(0, 2, viewOnlyDoc)]
     const snapshot = [...messages]
-    filterLoadedMessages(messages, 'src.event_data.events[].name', 'Auth')
+    filterLoadedMessages(messages, [{ field: 'src.event_data.events[].name', value: 'Auth', op: 'eq' }])
     expect(messages).toEqual(snapshot)
   })
 
   it('matches a top-level scalar path', () => {
     const messages = [row(0, 1, '{"event_type":"batch"}'), row(0, 2, '{"event_type":"single"}')]
-    const matches = filterLoadedMessages(messages, 'event_type', 'batch')
+    const matches = filterLoadedMessages(messages, [{ field: 'event_type', value: 'batch', op: 'eq' }])
     expect(matches).toHaveLength(1)
     expect(matches[0].offset).toBe(1)
+  })
+})
+
+describe('filterLoadedMessages with several conditions', () => {
+  const signup = '{"user":{"id":"42"},"event":"signup"}'
+  const logout = '{"user":{"id":"7"},"event":"logout"}'
+  const messages = [row(0, 1, signup), row(0, 2, logout)]
+
+  const idIs42 = { field: 'user.id', value: '42', op: 'eq' as const }
+  const eventIsLogout = { field: 'event', value: 'logout', op: 'eq' as const }
+
+  it('and keeps only rows satisfying every condition', () => {
+    expect(filterLoadedMessages(messages, [idIs42, eventIsLogout], 'and')).toEqual([])
+  })
+
+  it('or keeps rows satisfying any condition', () => {
+    const matches = filterLoadedMessages(messages, [idIs42, eventIsLogout], 'or')
+    expect(matches.map((m) => m.offset)).toEqual([1, 2])
+  })
+
+  // A half-filled row in the filter dialog must narrow nothing rather than
+  // matching everything and quietly widening the result.
+  it('ignores a condition with no field', () => {
+    const matches = filterLoadedMessages(messages, [idIs42, { field: '  ', value: 'x', op: 'eq' }], 'and')
+    expect(matches.map((m) => m.offset)).toEqual([1])
   })
 })

--- a/frontend/src/stores/kafka.ts
+++ b/frontend/src/stores/kafka.ts
@@ -41,18 +41,16 @@ interface KafkaTopicTabState {
   // `nextCursor`/`hasMore`; the visible rows are derived from `messages`
   // + this predicate (see filterLoadedMessages), so clearing it restores the
   // page and cursor instantly because they were never mutated.
-  filterField: string
-  filterOp: KafkaMatchOp
-  filterValue: string
+  filterConditions: KafkaMatchCondition[]
+  filterMode: KafkaMatchMode
   filterActive: boolean
 
   // "Search topic" — the budgeted BACKEND scan (match_field/match_value ->
   // messages.go). Each step scans one window under the reader's scan budget and
   // returns whatever it matched plus a cursor to continue deeper. `messages`
   // holds the accumulated matches while a search session is active.
-  searchField: string
-  searchValue: string
-  searchOp: KafkaMatchOp
+  searchConditions: KafkaMatchCondition[]
+  searchMode: KafkaMatchMode
   // Автоцикл «Search all»: гоняет шаги скана до начала лога.
   deepScanning: boolean
   deepScanCanceled: boolean
@@ -90,10 +88,27 @@ interface KafkaTopicTabState {
 // way to look for a field whose values are not known yet.
 export type KafkaMatchOp = 'eq' | 'exists' | 'missing'
 
-interface KafkaSearch {
+// One condition of a content search: a JSON path, what it must satisfy, and
+// the value to compare when the op is 'eq'.
+export interface KafkaMatchCondition {
   field: string
   value: string
   op: KafkaMatchOp
+}
+
+// How a set of conditions combines. 'and' narrows (every condition must hold),
+// 'or' widens (any one does).
+export type KafkaMatchMode = 'and' | 'or'
+
+interface KafkaSearch {
+  conditions: KafkaMatchCondition[]
+  mode: KafkaMatchMode
+}
+
+// A condition with no field is incomplete, not a wildcard: an empty row in the
+// filter dialog must never widen a search.
+export function activeConditions(conditions: KafkaMatchCondition[]): KafkaMatchCondition[] {
+  return conditions.filter((condition) => condition.field.trim() !== '')
 }
 
 // Which end of the log a browse starts from. 'newest' anchors at the end and
@@ -157,7 +172,7 @@ interface KafkaStore {
   // Explicit user "Refresh" of the current view (header + toolbar buttons, the
   // produce-then-refresh path). Search-aware: if a "Search topic" session is
   // active for this tab, re-run that search from the top (a fresh first step
-  // with the tab's existing searchField/searchValue) instead of browse-
+  // with the tab's existing search conditions) instead of browse-
   // overwriting the accumulated scan matches/cursor; otherwise reload the
   // newest browse page via fetchMessages. Restores the pre-Task-7 intent
   // (Refresh keeps you looking at the same kind of thing) on top of the new
@@ -174,16 +189,15 @@ interface KafkaStore {
   // interchangeable.
   setDirection: (connId: string, topic: string, tabId: string, direction: KafkaDirection) => Promise<void>
   // Filter loaded (client-side, no network).
-  setLoadedFilter: (tabId: string, field: string, value: string, op?: KafkaMatchOp) => void
+  setLoadedFilter: (tabId: string, conditions: KafkaMatchCondition[], mode?: KafkaMatchMode) => void
   clearLoadedFilter: (tabId: string) => void
   // Search topic (budgeted backend scan).
   searchTopic: (
     connId: string,
     topic: string,
     tabId: string,
-    field: string,
-    value: string,
-    op?: KafkaMatchOp
+    conditions: KafkaMatchCondition[],
+    mode?: KafkaMatchMode
   ) => Promise<void>
   scanMore: (connId: string, topic: string, tabId: string) => Promise<void>
   scanAll: (connId: string, topic: string, tabId: string) => Promise<void>
@@ -209,13 +223,11 @@ function defaultTabState(): KafkaTopicTabState {
     partitionFilter: null,
     seekOffset: '',
     seekTimestamp: '',
-    filterField: '',
-    filterValue: '',
-    filterOp: 'eq',
+    filterConditions: [],
+    filterMode: 'and',
     filterActive: false,
-    searchField: '',
-    searchValue: '',
-    searchOp: 'eq',
+    searchConditions: [],
+    searchMode: 'and',
     deepScanning: false,
     deepScanCanceled: false,
     searchActive: false,
@@ -244,18 +256,29 @@ function ensureState(tabs: Record<string, KafkaTopicTabState>, tabId: string): K
 // Non-JSON rows never match a non-empty path and are filtered out. Pure and
 // side-effect free, so the caller derives the visible set without ever mutating
 // the raw `messages`/cursor state.
+function conditionMatches(row: KafkaMessageRow, condition: KafkaMatchCondition): boolean {
+  const path = condition.field.trim()
+  if (condition.op === 'exists' || condition.op === 'missing') {
+    return fieldPresence(row.value, path, condition.op === 'exists')
+  }
+  return matchField(row.value, path, condition.value)
+}
+
+// filterLoadedMessages narrows the rows already on screen — no network. It
+// mirrors the backend scan predicate (messages.go) so that "Filter loaded" and
+// "Search topic" never disagree about what matches.
 export function filterLoadedMessages(
   messages: KafkaMessageRow[],
-  field: string,
-  value: string,
-  op: KafkaMatchOp = 'eq'
+  conditions: KafkaMatchCondition[],
+  mode: KafkaMatchMode = 'and'
 ): KafkaMessageRow[] {
-  const path = field.trim()
-  if (path === '') return messages
-  if (op === 'exists' || op === 'missing') {
-    return messages.filter((row) => fieldPresence(row.value, path, op === 'exists'))
-  }
-  return messages.filter((row) => matchField(row.value, path, value))
+  const active = activeConditions(conditions)
+  if (active.length === 0) return messages
+  return messages.filter((row) =>
+    mode === 'or'
+      ? active.some((condition) => conditionMatches(row, condition))
+      : active.every((condition) => conditionMatches(row, condition))
+  )
 }
 
 interface MessagesResponse {
@@ -371,9 +394,15 @@ async function requestMessages(
     }
   }
   if (search) {
-    filters.push({ column: 'match_field', op: 'eq', value: search.field })
-    filters.push({ column: 'match_value', op: 'eq', value: search.value })
-    filters.push({ column: 'match_op', op: 'eq', value: search.op })
+    // The first condition goes on the unsuffixed keys and the rest are
+    // numbered; parseMatchQuery in messages.go reads both.
+    activeConditions(search.conditions).forEach((condition, index) => {
+      const suffix = index === 0 ? '' : `.${index}`
+      filters.push({ column: `match_field${suffix}`, op: 'eq', value: condition.field })
+      filters.push({ column: `match_value${suffix}`, op: 'eq', value: condition.value })
+      filters.push({ column: `match_op${suffix}`, op: 'eq', value: condition.op })
+    })
+    filters.push({ column: 'match_mode', op: 'eq', value: search.mode })
   }
 
   const params = new URLSearchParams({ limit: '100' })
@@ -402,7 +431,7 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
     if (current.scanning) return
     if (!reset && (!current.hasMore || !current.nextCursor)) return
 
-    const search: KafkaSearch = { field: current.searchField, value: current.searchValue, op: current.searchOp }
+    const search: KafkaSearch = { conditions: current.searchConditions, mode: current.searchMode }
     const cursorOffsets = reset ? null : current.nextCursor
 
     // Supersede any lingering controller and register this step's own so Cancel
@@ -655,7 +684,7 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
     refreshMessages: async (connId, topic, tabId) => {
       const current = ensureState(get().tabs, tabId)
       if (current.searchActive) {
-        await get().searchTopic(connId, topic, tabId, current.searchField, current.searchValue, current.searchOp)
+        await get().searchTopic(connId, topic, tabId, current.searchConditions, current.searchMode)
         return
       }
       await get().fetchMessages(connId, topic, tabId)
@@ -746,13 +775,11 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
             messages: [],
             nextCursor: null,
             hasMore: false,
-            filterField: '',
-            filterValue: '',
-            filterOp: 'eq',
+            filterConditions: [],
+            filterMode: 'and',
             filterActive: false,
-            searchField: '',
-            searchValue: '',
-            searchOp: 'eq',
+            searchConditions: [],
+            searchMode: 'and',
             searchActive: false,
             deepScanning: false,
             deepScanCanceled: false,
@@ -802,8 +829,8 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
           },
         },
       }))
-      if (previous.searchActive && previous.searchField) {
-        await get().searchTopic(connId, topic, tabId, previous.searchField, previous.searchValue, previous.searchOp)
+      if (previous.searchActive && previous.searchConditions.length > 0) {
+        await get().searchTopic(connId, topic, tabId, previous.searchConditions, previous.searchMode)
         return
       }
       await get().fetchMessages(connId, topic, tabId)
@@ -837,24 +864,23 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
       }))
       // A search survives the flip for the same reason it survives a seek: the
       // direction changes which part of the log is swept, not what is looked for.
-      if (previous.searchActive && previous.searchField) {
-        await get().searchTopic(connId, topic, tabId, previous.searchField, previous.searchValue, previous.searchOp)
+      if (previous.searchActive && previous.searchConditions.length > 0) {
+        await get().searchTopic(connId, topic, tabId, previous.searchConditions, previous.searchMode)
         return
       }
       await get().fetchMessages(connId, topic, tabId)
     },
 
-    setLoadedFilter: (tabId, field, value, op = 'eq') => {
-      const trimmed = field.trim()
+    setLoadedFilter: (tabId, conditions, mode = 'and') => {
+      const active = activeConditions(conditions)
       set((state) => ({
         tabs: {
           ...state.tabs,
           [tabId]: {
             ...ensureState(state.tabs, tabId),
-            filterField: trimmed,
-            filterValue: op === 'eq' ? value : '',
-            filterOp: op,
-            filterActive: trimmed !== '',
+            filterConditions: active,
+            filterMode: mode,
+            filterActive: active.length > 0,
           },
         },
       }))
@@ -866,35 +892,30 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
           ...state.tabs,
           [tabId]: {
             ...ensureState(state.tabs, tabId),
-            filterField: '',
-            filterValue: '',
-            filterOp: 'eq',
+            filterConditions: [],
+            filterMode: 'and',
             filterActive: false,
           },
         },
       }))
     },
 
-    searchTopic: async (connId, topic, tabId, field, value, op = 'eq') => {
-      const trimmed = field.trim()
-      if (trimmed === '') return
+    searchTopic: async (connId, topic, tabId, conditions, mode = 'and') => {
+      const active = activeConditions(conditions)
+      if (active.length === 0) return
       set((state) => ({
         tabs: {
           ...state.tabs,
           [tabId]: {
             ...ensureState(state.tabs, tabId),
-            searchField: trimmed,
-            // A presence search has no value to compare; keep it empty so a
-            // stale one cannot leak back in when the op switches to 'eq'.
-            searchValue: op === 'eq' ? value : '',
-            searchOp: op,
+            searchConditions: active,
+            searchMode: mode,
             deepScanCanceled: false,
             searchActive: true,
             // A topic scan replaces the loaded view with its matches; drop any
             // client-side filter so the two operations never stack on one set.
-            filterField: '',
-            filterValue: '',
-            filterOp: 'eq',
+            filterConditions: [],
+            filterMode: 'and',
             filterActive: false,
           },
         },
@@ -978,9 +999,8 @@ export const useKafkaStore = create<KafkaStore>((set, get) => {
           ...state.tabs,
           [tabId]: {
             ...ensureState(state.tabs, tabId),
-            searchField: '',
-            searchValue: '',
-            searchOp: 'eq',
+            searchConditions: [],
+            searchMode: 'and',
             searchActive: false,
             deepScanning: false,
             deepScanCanceled: false,

--- a/frontend/src/stores/workspace.test.ts
+++ b/frontend/src/stores/workspace.test.ts
@@ -136,13 +136,13 @@ describe('refreshTree — stale-while-revalidate', () => {
     expect(useWorkspaceStore.getState().treeRefreshingByConnection[CONN]).toBeFalsy()
   })
 
-  it('re-reads an expanded namespace and leaves it expanded', async () => {
+  // The Redis tree is one flat page grouped on the client, so a refresh re-reads
+  // the root and nothing else — and an open folder stays open, because expansion
+  // is no longer tied to a fetched level.
+  it('re-reads only the root and leaves an expanded namespace expanded', async () => {
     useWorkspaceStore.setState({
-      treeItems: {
-        [rootKey]: [{ name: 'profile', type: 'schema' }] as never,
-        [nsKey('profile')]: keyPage(['profile:1']).objects as never,
-      },
-      treeLoadedByKey: { [rootKey]: true, [nsKey('profile')]: true },
+      treeItems: { [rootKey]: keyPage(['profile:1']).objects as never },
+      treeLoadedByKey: { [rootKey]: true },
       expandedSchemas: new Set([nsKey('profile')]),
     })
     const requested: string[] = []
@@ -150,16 +150,15 @@ describe('refreshTree — stale-while-revalidate', () => {
       'fetch',
       vi.fn(async (url: string) => {
         requested.push(String(url))
-        return String(url).includes('path=profile')
-          ? jsonResponse(keyPage(['profile:1', 'profile:2']))
-          : jsonResponse({ objects: [{ name: 'profile', type: 'schema' }], next_cursor: '' })
+        return jsonResponse(keyPage(['profile:1', 'profile:2']))
       }) as unknown as typeof fetch
     )
 
     await useWorkspaceStore.getState().refreshTree(CONN)
 
-    expect(requested.some((url) => url.includes('path=profile'))).toBe(true)
-    expect(names(nsKey('profile'))).toEqual(['profile:1', 'profile:2'])
+    expect(requested.filter((url) => url.includes('path=')).length).toBe(0)
+    expect(requested.some((url) => url.includes('flat=1'))).toBe(true)
+    expect(names(rootKey)).toEqual(['profile:1', 'profile:2'])
     expect(useWorkspaceStore.getState().expandedSchemas.has(nsKey('profile'))).toBe(true)
   })
 
@@ -183,28 +182,42 @@ describe('refreshTree — stale-while-revalidate', () => {
     expect(requested.filter((url) => url.includes('path=')).length).toBe(0)
   })
 
-  it('drops cached pages for a namespace that no longer exists', async () => {
+  // Scan more continues from the cursor and appends. SCAN can hand back a key it
+  // already returned, so the append must not double-count it.
+  it('appends a continued scan and drops keys already held', async () => {
     useWorkspaceStore.setState({
-      treeItems: {
-        [rootKey]: [
-          { name: 'profile', type: 'schema' },
-          { name: 'gone', type: 'schema' },
-        ] as never,
-        [nsKey('gone')]: keyPage(['gone:1']).objects as never,
-      },
-      treeCursors: { [nsKey('gone')]: 'stale-cursor' },
-      treeLoadedByKey: { [rootKey]: true, [nsKey('gone')]: true },
-      expandedSchemas: new Set<string>(),
+      treeItems: { [rootKey]: keyPage(['profile:1', 'profile:2']).objects as never },
+      treeCursors: { [rootKey]: 'cursor-7' },
+      treeLoadedByKey: { [rootKey]: true },
     })
+    const requested: string[] = []
     vi.stubGlobal(
       'fetch',
-      vi.fn(async () => jsonResponse({ objects: [{ name: 'profile', type: 'schema' }], next_cursor: '' })) as unknown as typeof fetch
+      vi.fn(async (url: string) => {
+        requested.push(String(url))
+        return jsonResponse(keyPage(['profile:2', 'profile:3'], ''))
+      }) as unknown as typeof fetch
     )
 
-    await useWorkspaceStore.getState().refreshTree(CONN)
+    await useWorkspaceStore.getState().scanMoreKeys(CONN)
 
-    expect(useWorkspaceStore.getState().treeItems[nsKey('gone')]).toBeUndefined()
-    expect(useWorkspaceStore.getState().treeCursors[nsKey('gone')]).toBeUndefined()
+    expect(requested.some((url) => url.includes('cursor=cursor-7'))).toBe(true)
+    expect(names(rootKey)).toEqual(['profile:1', 'profile:2', 'profile:3'])
+    expect(useWorkspaceStore.getState().treeCursors[rootKey]).toBe('')
+  })
+
+  it('does nothing when there is no cursor to continue from', async () => {
+    useWorkspaceStore.setState({
+      treeItems: { [rootKey]: keyPage(['profile:1']).objects as never },
+      treeCursors: { [rootKey]: '' },
+    })
+    const fetchMock = vi.fn(async () => jsonResponse(keyPage(['profile:9'])))
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await useWorkspaceStore.getState().scanMoreKeys(CONN)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(names(rootKey)).toEqual(['profile:1'])
   })
 
   it('does not let a slower earlier refresh overwrite a newer one', async () => {

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -441,9 +441,26 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     if ((get().keyPatternByConnection[connId] ?? '') === pattern) {
       return
     }
-    set((state) => ({
-      keyPatternByConnection: { ...state.keyPatternByConnection, [connId]: pattern },
-    }))
+    set((state) => {
+      // Every cached level of this tree was scanned under the OLD pattern, so all
+      // of it is now wrong -- including levels that are currently collapsed.
+      // refreshTree alone is not enough: it re-reads the root and the expanded
+      // namespaces, while a collapsed namespace keeps its entry, and expanding it
+      // renders that entry without refetching (ObjectTree only fetches a level it
+      // has no items for). The result was a filtered count over an unfiltered
+      // list of children.
+      const isOtherConnection = (key: string) => parseTreeKey(key).connId !== connId
+      const keep = <T,>(record: Record<string, T>): Record<string, T> =>
+        Object.fromEntries(Object.entries(record).filter(([key]) => isOtherConnection(key)))
+
+      return {
+        keyPatternByConnection: { ...state.keyPatternByConnection, [connId]: pattern },
+        treeItems: keep(state.treeItems),
+        treeCursors: keep(state.treeCursors),
+        treeLoadedByKey: keep(state.treeLoadedByKey),
+        treeErrorByKey: keep(state.treeErrorByKey),
+      }
+    })
     await get().refreshTree(connId)
   },
 

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -89,10 +89,12 @@ interface WorkspaceStore {
   visibleSchemasByConnection: Record<string, string[] | null>
   availableSchemasByConnection: Record<string, string[]>
   selectedNodeByConnection: Record<string, string>
+  keyPatternByConnection: Record<string, string>
   treeConnByPage: Record<string, string>
 
   fetchTree: (connId: string, path?: string, opts?: { refresh?: boolean }) => Promise<void>
   setSelectedNode: (connId: string, node: string) => Promise<void>
+  setKeyPattern: (connId: string, pattern: string) => Promise<void>
   refreshTree: (connId: string) => Promise<void>
   toggleSchema: (connId: string, schema: string) => void
   setTreeVisibility: (key: TreeVisibilityKey, visible: boolean) => void
@@ -150,13 +152,18 @@ function isRedisConnection(connId: string): boolean {
   return useConnectionStore.getState().connections.find((connection) => connection.id === connId)?.type === 'redis'
 }
 
-function buildObjectsQuery(connId: string, path: string, opts: { paged: boolean; cursor?: string; node?: string }): string {
+function buildObjectsQuery(
+  connId: string,
+  path: string,
+  opts: { paged: boolean; cursor?: string; node?: string; match?: string }
+): string {
   const params = new URLSearchParams()
   if (path) params.set('path', path)
   if (opts.paged) {
     params.set('paged', '1')
     if (opts.cursor) params.set('cursor', opts.cursor)
     if (opts.node) params.set('node', opts.node)
+    if (opts.match) params.set('match', opts.match)
   }
   const query = params.toString()
   return `/api/connections/${connId}/objects${query ? `?${query}` : ''}`
@@ -252,6 +259,7 @@ function purgeTabsWhere(state: WorkspaceStore, isConnDead: (connId: string) => b
     treeErrorsByConnection: dropDeadKeys(state.treeErrorsByConnection),
     treeRefreshingByConnection: dropDeadKeys(state.treeRefreshingByConnection),
     selectedNodeByConnection: dropDeadKeys(state.selectedNodeByConnection),
+    keyPatternByConnection: dropDeadKeys(state.keyPatternByConnection),
     availableSchemasByConnection: dropDeadKeys(state.availableSchemasByConnection),
     visibleSchemasByConnection: dropDeadKeys(state.visibleSchemasByConnection),
     treeConnByPage: nextTreeConnByPage,
@@ -281,6 +289,7 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
   visibleSchemasByConnection: {},
   availableSchemasByConnection: {},
   selectedNodeByConnection: {},
+  keyPatternByConnection: {},
   treeConnByPage: {},
 
   fetchTree: async (connId: string, path?: string, opts?: { refresh?: boolean }) => {
@@ -319,7 +328,8 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       const paged = isRedisConnection(connId)
       try {
         const node = get().selectedNodeByConnection[connId]
-        const res = await fetchWithTimeout(buildObjectsQuery(connId, normalizedPath, { paged, node }))
+        const match = get().keyPatternByConnection[connId]
+        const res = await fetchWithTimeout(buildObjectsQuery(connId, normalizedPath, { paged, node, match }))
         if (!res.ok) {
           const body = await res.json().catch(() => ({ error: res.statusText }))
           throw new Error(body.error || 'Failed to fetch objects')
@@ -407,6 +417,20 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         ...state.selectedNodeByConnection,
         [connId]: node,
       },
+    }))
+    await get().refreshTree(connId)
+  },
+
+  // The key filter is per connection rather than per tree node: it narrows every
+  // level at once, so changing it re-reads the whole tree the way switching
+  // cluster node does. Re-applying the same pattern is a no-op so that a
+  // debounced input settling on its current value costs no SCAN.
+  setKeyPattern: async (connId: string, pattern: string) => {
+    if ((get().keyPatternByConnection[connId] ?? '') === pattern) {
+      return
+    }
+    set((state) => ({
+      keyPatternByConnection: { ...state.keyPatternByConnection, [connId]: pattern },
     }))
     await get().refreshTree(connId)
   },

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -50,7 +50,18 @@ export interface RedisCliTab {
   label: string
 }
 
-export type WorkspaceTab = ObjectTab | SqlTab | RedisCliTab
+// Server-wide telemetry rather than one object: memory, limits and key counts
+// belong to the connection, so the tab carries no object name. One per
+// connection — a second Overview of the same server would show the same thing.
+export interface OverviewTab {
+  kind: 'overview'
+  id: string
+  connId: string
+  anchorConnId?: string
+  label: string
+}
+
+export type WorkspaceTab = ObjectTab | SqlTab | RedisCliTab | OverviewTab
 
 // Page a tab belongs to: its anchor when it targets a sibling database,
 // otherwise its own connection.
@@ -113,6 +124,7 @@ interface WorkspaceStore {
   goBackFromTab: (tabId: string) => void
   openSqlTab: (connId: string) => void
   openRedisCliTab: (connId: string) => void
+  openOverviewTab: (connId: string) => void
   closeTab: (tabId: string) => void
   setActiveTab: (tabId: string) => void
   openConnection: (connId: string) => void
@@ -762,6 +774,18 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       connId,
       label: sequence === 1 ? 'Redis CLI' : `Redis CLI ${sequence}`,
     }
+    set({ tabs: [...tabs, tab], activeTabId: id })
+  },
+
+  openOverviewTab: (connId: string) => {
+    const { tabs } = get()
+    const id = `${connId}:overview`
+    if (tabs.some((tab) => tab.id === id)) {
+      set({ activeTabId: id })
+      return
+    }
+
+    const tab: OverviewTab = { kind: 'overview', id, connId, label: 'Overview' }
     set({ tabs: [...tabs, tab], activeTabId: id })
   },
 

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -106,6 +106,7 @@ interface WorkspaceStore {
   fetchTree: (connId: string, path?: string, opts?: { refresh?: boolean }) => Promise<void>
   setSelectedNode: (connId: string, node: string) => Promise<void>
   setKeyPattern: (connId: string, pattern: string) => Promise<void>
+  scanMoreKeys: (connId: string) => Promise<void>
   refreshTree: (connId: string) => Promise<void>
   toggleSchema: (connId: string, schema: string) => void
   setTreeVisibility: (key: TreeVisibilityKey, visible: boolean) => void
@@ -167,7 +168,7 @@ function isRedisConnection(connId: string): boolean {
 function buildObjectsQuery(
   connId: string,
   path: string,
-  opts: { paged: boolean; cursor?: string; node?: string; match?: string }
+  opts: { paged: boolean; cursor?: string; node?: string; match?: string; flat?: boolean }
 ): string {
   const params = new URLSearchParams()
   if (path) params.set('path', path)
@@ -176,6 +177,9 @@ function buildObjectsQuery(
     if (opts.cursor) params.set('cursor', opts.cursor)
     if (opts.node) params.set('node', opts.node)
     if (opts.match) params.set('match', opts.match)
+    // Redis returns one flat page of keys and the tree is grouped on the client,
+    // so opening a namespace never costs a second scan.
+    if (opts.flat) params.set('flat', '1')
   }
   const query = params.toString()
   return `/api/connections/${connId}/objects${query ? `?${query}` : ''}`
@@ -341,7 +345,9 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       try {
         const node = get().selectedNodeByConnection[connId]
         const match = get().keyPatternByConnection[connId]
-        const res = await fetchWithTimeout(buildObjectsQuery(connId, normalizedPath, { paged, node, match }))
+        const res = await fetchWithTimeout(
+          buildObjectsQuery(connId, normalizedPath, { paged, node, match, flat: paged })
+        )
         if (!res.ok) {
           const body = await res.json().catch(() => ({ error: res.statusText }))
           throw new Error(body.error || 'Failed to fetch objects')
@@ -433,22 +439,19 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     await get().refreshTree(connId)
   },
 
-  // The key filter is per connection rather than per tree node: it narrows every
-  // level at once, so changing it re-reads the whole tree the way switching
-  // cluster node does. Re-applying the same pattern is a no-op so that a
-  // debounced input settling on its current value costs no SCAN.
+  // The key filter drives the single scan the whole Redis tree is built from, so
+  // changing it re-runs that scan the way switching cluster node does.
+  // Re-applying the same pattern is a no-op, so a debounced input settling on
+  // its current value costs no SCAN.
   setKeyPattern: async (connId: string, pattern: string) => {
     if ((get().keyPatternByConnection[connId] ?? '') === pattern) {
       return
     }
     set((state) => {
-      // Every cached level of this tree was scanned under the OLD pattern, so all
-      // of it is now wrong -- including levels that are currently collapsed.
-      // refreshTree alone is not enough: it re-reads the root and the expanded
-      // namespaces, while a collapsed namespace keeps its entry, and expanding it
-      // renders that entry without refetching (ObjectTree only fetches a level it
-      // has no items for). The result was a filtered count over an unfiltered
-      // list of children.
+      // Everything cached for this tree came from a scan under the OLD pattern,
+      // so all of it is now wrong. Dropped rather than refreshed in place: a
+      // continued scan (Scan more) appends to what is already there, and merging
+      // pages from two different patterns would be worse than an empty tree.
       const isOtherConnection = (key: string) => parseTreeKey(key).connId !== connId
       const keep = <T,>(record: Record<string, T>): Record<string, T> =>
         Object.fromEntries(Object.entries(record).filter(([key]) => isOtherConnection(key)))
@@ -464,16 +467,75 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
     await get().refreshTree(connId)
   },
 
+  // Continues the Redis scan from where the last page stopped and appends what
+  // it finds. The tree is grouped on the client from one flat list, so appending
+  // keys is all it takes for namespaces and their counts to grow -- no level
+  // needs re-reading.
+  scanMoreKeys: async (connId: string) => {
+    const key = buildTreeKey(connId)
+    const cursor = get().treeCursors[key]
+    if (!cursor || get().treeLoadingByKey[key]) {
+      return
+    }
+
+    set((state) => {
+      const loadingByKey = { ...state.treeLoadingByKey, [key]: true }
+      return { treeLoadingByKey: loadingByKey, treeLoading: hasLoadingTreeRequests(loadingByKey) }
+    })
+
+    try {
+      const node = get().selectedNodeByConnection[connId]
+      const match = get().keyPatternByConnection[connId]
+      const res = await fetchWithTimeout(
+        buildObjectsQuery(connId, '', { paged: true, cursor, node, match, flat: true })
+      )
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error || 'Failed to fetch more keys')
+      }
+
+      const page = (await res.json()) as ObjectPageResponse
+      set((state) => {
+        // A key can come back twice across pages: SCAN guarantees every key
+        // present for the whole iteration is returned at least once, not at most
+        // once. Deduplicating here keeps the tree honest about its counts.
+        const seen = new Set((state.treeItems[key] ?? []).map((item) => item.path ?? item.name))
+        const added = (page.objects ?? []).filter((item) => !seen.has(item.path ?? item.name))
+        const loadingByKey = { ...state.treeLoadingByKey, [key]: false }
+        return {
+          treeItems: { ...state.treeItems, [key]: [...(state.treeItems[key] ?? []), ...added] },
+          treeCursors: { ...state.treeCursors, [key]: page.next_cursor ?? '' },
+          treeLoadingByKey: loadingByKey,
+          treeLoading: hasLoadingTreeRequests(loadingByKey),
+        }
+      })
+    } catch (error) {
+      set((state) => {
+        const loadingByKey = { ...state.treeLoadingByKey, [key]: false }
+        return {
+          treeLoadingByKey: loadingByKey,
+          treeErrorByKey: { ...state.treeErrorByKey, [key]: (error as Error).message },
+          treeLoading: hasLoadingTreeRequests(loadingByKey),
+        }
+      })
+    }
+  },
+
   // refreshTree re-reads the root plus every currently expanded namespace of one
   // connection, stale-while-revalidate: the existing tree stays visible for the
   // whole request and is replaced per key only when a newer response lands. It
   // used to delete every cached page up front, which blanked the sidebar on each
   // refresh and lost the rows entirely if the request then failed.
   refreshTree: async (connId: string) => {
-    const expandedNamespaces = Array.from(get().expandedSchemas)
-      .filter((key) => parseTreeKey(key).connId === connId)
-      .map((key) => parseTreeKey(key).path)
-      .filter((path) => path !== '')
+    // A Redis tree is one flat page grouped on the client, so its namespaces are
+    // not separately fetched levels and there is nothing per-namespace to
+    // refresh -- re-reading the root rebuilds all of it.
+    const expandedNamespaces = isRedisConnection(connId)
+      ? []
+      : Array.from(get().expandedSchemas)
+          .filter((key) => parseTreeKey(key).connId === connId)
+          .map((key) => parseTreeKey(key).path)
+          .filter((path) => path !== '')
 
     const generation = (treeRefreshSeq.get(connId) ?? 0) + 1
     treeRefreshSeq.set(connId, generation)
@@ -490,6 +552,13 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
       ])
 
       if (!isNewestRefresh()) {
+        return
+      }
+
+      // A Redis tree has no per-namespace cache to prune, and its root items are
+      // keys rather than namespaces -- running the sweep below against them would
+      // find no "live namespace" for any expanded folder and collapse every one.
+      if (isRedisConnection(connId)) {
         return
       }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -345,3 +345,14 @@ export interface LinkRecord {
 }
 
 export type LinkInput = Omit<LinkRecord, 'id'>
+
+// GET /api/connections/:id/info. Extra is connector-specific: everything past
+// the four common fields is whatever that source reports about itself, so it is
+// read defensively rather than typed per connector.
+export interface ConnectionInfo {
+  version: string
+  database: string
+  host: string
+  port: string
+  extra?: Record<string, unknown>
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/twmb/franz-go v1.21.3
 	github.com/twmb/franz-go/pkg/kadm v1.18.0
+	github.com/twmb/franz-go/pkg/kmsg v1.13.1
 	golang.org/x/sync v0.20.0
 )
 
@@ -19,7 +20,6 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/pierrec/lz4/v4 v4.1.26 // indirect
-	github.com/twmb/franz-go/pkg/kmsg v1.13.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/internal/api/handlers/objects.go
+++ b/internal/api/handlers/objects.go
@@ -46,6 +46,7 @@ func (h *ObjectsHandler) ListObjects(w http.ResponseWriter, r *http.Request) {
 			Path:   path,
 			Cursor: query.Get("cursor"),
 			Node:   query.Get("node"),
+			Match:  query.Get("match"),
 		})
 		if err != nil {
 			writeConnectorError(w, err)

--- a/internal/api/handlers/objects.go
+++ b/internal/api/handlers/objects.go
@@ -47,6 +47,7 @@ func (h *ObjectsHandler) ListObjects(w http.ResponseWriter, r *http.Request) {
 			Cursor: query.Get("cursor"),
 			Node:   query.Get("node"),
 			Match:  query.Get("match"),
+			Flat:   query.Get("flat") == "1",
 		})
 		if err != nil {
 			writeConnectorError(w, err)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -43,10 +43,12 @@ type Object struct {
 // ObjectPageOpts selects one page of an incremental object listing.
 // Cursor is an opaque token from a previous page ("" = first page).
 // Node optionally pins the listing to a single cluster node.
+// Match optionally narrows the page to names matching a glob, scoped to Path.
 type ObjectPageOpts struct {
 	Path   string
 	Cursor string
 	Node   string
+	Match  string
 }
 
 type ObjectPage struct {

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -44,11 +44,15 @@ type Object struct {
 // Cursor is an opaque token from a previous page ("" = first page).
 // Node optionally pins the listing to a single cluster node.
 // Match optionally narrows the page to names matching a glob, scoped to Path.
+// Flat returns the page's objects as they are, without grouping them into
+// namespaces — the caller builds whatever hierarchy it wants from the names, so
+// one scan answers for the whole tree instead of one scan per level.
 type ObjectPageOpts struct {
 	Path   string
 	Cursor string
 	Node   string
 	Match  string
+	Flat   bool
 }
 
 type ObjectPage struct {

--- a/internal/connector/kafka/field_presence_test.go
+++ b/internal/connector/kafka/field_presence_test.go
@@ -110,9 +110,12 @@ func TestParseMatchFilterOp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, op := parseMatchFilter(tt.filters)
-			if op != tt.want {
-				t.Fatalf("parseMatchFilter op = %q, want %q", op, tt.want)
+			query := parseMatchQuery(tt.filters)
+			if len(query.filters) != 1 {
+				t.Fatalf("expected one condition, got %d", len(query.filters))
+			}
+			if query.filters[0].op != tt.want {
+				t.Fatalf("parseMatchQuery op = %q, want %q", query.filters[0].op, tt.want)
 			}
 		})
 	}

--- a/internal/connector/kafka/kafka.go
+++ b/internal/connector/kafka/kafka.go
@@ -338,8 +338,11 @@ func unsupportedKafkaOperation(name string) error {
 	return fmt.Errorf("%w: kafka %s is not supported yet", connector.ErrBadRequest, name)
 }
 
-func (c *KafkaConnector) GetSchema(context.Context, string) (*connector.Schema, error) {
-	return nil, unsupportedKafkaOperation("schema")
+// GetSchema describes a topic: its partition count plus its broker-reported
+// configuration. Kafka has no columns, so Columns stays empty and everything
+// lands in Meta.
+func (c *KafkaConnector) GetSchema(ctx context.Context, object string) (*connector.Schema, error) {
+	return c.topicSchema(ctx, object)
 }
 
 func (c *KafkaConnector) GetObjectInfo(context.Context, string) (*connector.ObjectInfo, error) {

--- a/internal/connector/kafka/kafka_test.go
+++ b/internal/connector/kafka/kafka_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -383,19 +384,112 @@ func TestParseBeforeOffsets(t *testing.T) {
 	}
 }
 
-func TestParseMatchFilter(t *testing.T) {
+func TestParseMatchQuery(t *testing.T) {
 	t.Parallel()
 
-	field, value, _ := parseMatchFilter([]connector.FilterExpr{
+	query := parseMatchQuery([]connector.FilterExpr{
 		{Column: "match_field", Value: " user.id "},
 		{Column: "match_value", Value: "42"},
 	})
-	if field != "user.id" || value != "42" {
-		t.Fatalf("unexpected match filter: field=%q value=%q", field, value)
+	if len(query.filters) != 1 {
+		t.Fatalf("expected one condition, got %d", len(query.filters))
+	}
+	if query.filters[0].field != "user.id" || query.filters[0].value != "42" {
+		t.Fatalf("unexpected match filter: %+v", query.filters[0])
+	}
+	if query.mode != matchModeAnd {
+		t.Fatalf("expected AND by default, got %q", query.mode)
 	}
 
-	if field, _, _ := parseMatchFilter(nil); field != "" {
-		t.Fatalf("expected empty field for no filter, got %q", field)
+	if parseMatchQuery(nil).active() {
+		t.Fatal("expected no search for an empty filter list")
+	}
+}
+
+func TestParseMatchQueryMultipleConditions(t *testing.T) {
+	t.Parallel()
+
+	query := parseMatchQuery([]connector.FilterExpr{
+		{Column: "match_field", Value: "user.id"},
+		{Column: "match_value", Value: "42"},
+		{Column: "match_field.1", Value: "event"},
+		{Column: "match_value.1", Value: "signup"},
+		{Column: "match_field.2", Value: "trace"},
+		{Column: "match_op.2", Value: "missing"},
+		{Column: "match_mode", Value: "or"},
+	})
+
+	if query.mode != matchModeOr {
+		t.Fatalf("mode = %q, want or", query.mode)
+	}
+	want := []contentFilter{
+		{field: "user.id", value: "42", op: matchOpEquals},
+		{field: "event", value: "signup", op: matchOpEquals},
+		{field: "trace", op: matchOpMissing},
+	}
+	if !reflect.DeepEqual(query.filters, want) {
+		t.Fatalf("filters = %+v, want %+v", query.filters, want)
+	}
+}
+
+// A condition whose field never arrived is dropped rather than matching
+// everything: a blank row in the filter dialog must not widen the search.
+func TestParseMatchQueryDropsFieldlessConditions(t *testing.T) {
+	t.Parallel()
+
+	query := parseMatchQuery([]connector.FilterExpr{
+		{Column: "match_field", Value: "user.id"},
+		{Column: "match_value.1", Value: "orphaned"},
+		{Column: "match_field.2", Value: "   "},
+	})
+
+	if len(query.filters) != 1 || query.filters[0].field != "user.id" {
+		t.Fatalf("expected only the complete condition, got %+v", query.filters)
+	}
+}
+
+func TestMessageMatchesQueryCombinesConditions(t *testing.T) {
+	t.Parallel()
+
+	row := map[string]any{"format": "json", "value": `{"user":{"id":"42"},"event":"signup"}`}
+	idMatches := contentFilter{field: "user.id", value: "42", op: matchOpEquals}
+	eventMisses := contentFilter{field: "event", value: "logout", op: matchOpEquals}
+
+	tests := []struct {
+		name  string
+		query matchQuery
+		want  bool
+	}{
+		{
+			name:  "and needs every condition",
+			query: matchQuery{mode: matchModeAnd, filters: []contentFilter{idMatches, eventMisses}},
+			want:  false,
+		},
+		{
+			name:  "and accepts when all hold",
+			query: matchQuery{mode: matchModeAnd, filters: []contentFilter{idMatches, idMatches}},
+			want:  true,
+		},
+		{
+			name:  "or needs only one",
+			query: matchQuery{mode: matchModeOr, filters: []contentFilter{idMatches, eventMisses}},
+			want:  true,
+		},
+		{
+			name:  "or rejects when none hold",
+			query: matchQuery{mode: matchModeOr, filters: []contentFilter{eventMisses, eventMisses}},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := messageMatchesQuery(row, tt.query); got != tt.want {
+				t.Fatalf("messageMatchesQuery = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/connector/kafka/messages.go
+++ b/internal/connector/kafka/messages.go
@@ -280,8 +280,8 @@ func (c *KafkaConnector) GetData(ctx context.Context, topic string, opts connect
 	if err != nil {
 		return nil, err
 	}
-	matchField, matchValue, matchOperator := parseMatchFilter(opts.Filters)
-	scanning := matchField != ""
+	matchQ := parseMatchQuery(opts.Filters)
+	scanning := matchQ.active()
 	seek, err := parseSeek(opts.Filters)
 	if err != nil {
 		return nil, err
@@ -462,7 +462,7 @@ func (c *KafkaConnector) GetData(ctx context.Context, topic string, opts connect
 		}
 		// Content search must inspect every candidate, so it deserializes them all
 		// before testing the match predicate.
-		rows = filterMatches(finalizeRows(rows), matchField, matchValue, matchOperator)
+		rows = filterMatches(finalizeRows(rows), matchQ)
 		meta["matched"] = len(rows)
 	} else {
 		// Deferred deserialization: only the rows that survived page selection are
@@ -1370,28 +1370,96 @@ const (
 	matchOpMissing matchOp = "missing"
 )
 
-// parseMatchFilter extracts the content-search predicate. An empty field means
-// no search (normal windowed paging). The value is compared verbatim, and is
-// ignored entirely unless the op is matchOpEquals. An absent or unrecognized
-// match_op falls back to matchOpEquals.
-func parseMatchFilter(filters []connector.FilterExpr) (field string, value string, op matchOp) {
-	op = matchOpEquals
+// matchMode combines a multi-condition search. AND is the default because it is
+// what narrowing means: each condition added removes messages.
+type matchMode string
+
+const (
+	matchModeAnd matchMode = "and"
+	matchModeOr  matchMode = "or"
+)
+
+// contentFilter is one field predicate of a content search.
+type contentFilter struct {
+	field string
+	value string
+	op    matchOp
+}
+
+// matchQuery is the whole content search: the conditions and how they combine.
+type matchQuery struct {
+	filters []contentFilter
+	mode    matchMode
+}
+
+// active reports whether anything is being searched for. An empty query means
+// normal windowed paging rather than a scan.
+func (q matchQuery) active() bool { return len(q.filters) > 0 }
+
+// parseMatchQuery extracts the content-search predicate.
+//
+// Conditions are numbered: match_field/match_value/match_op carry the first, and
+// match_field.N/match_value.N/match_op.N carry the rest. A flat key/value list is
+// the shape FilterExpr gives us, and a numeric suffix is the ordinary way to put
+// a list into one — the alternative, a nested filter object, would change the
+// contract every connector shares for the sake of one of them.
+//
+// A condition with an empty field is dropped, so trailing blank rows in the UI
+// cost nothing. The value is compared verbatim and is ignored entirely unless
+// the op is matchOpEquals. An absent or unrecognized match_op falls back to
+// matchOpEquals, and an absent or unrecognized match_mode to AND — so a
+// single-condition request is byte-for-byte what it was before.
+func parseMatchQuery(filters []connector.FilterExpr) matchQuery {
+	byIndex := make(map[string]*contentFilter)
+	order := make([]string, 0, 4)
+	query := matchQuery{mode: matchModeAnd}
+
+	at := func(index string) *contentFilter {
+		if existing, ok := byIndex[index]; ok {
+			return existing
+		}
+		created := &contentFilter{op: matchOpEquals}
+		byIndex[index] = created
+		order = append(order, index)
+		return created
+	}
+
 	for _, filter := range filters {
-		switch strings.ToLower(strings.TrimSpace(filter.Column)) {
+		column := strings.ToLower(strings.TrimSpace(filter.Column))
+		if column == "match_mode" {
+			if matchMode(strings.ToLower(strings.TrimSpace(filter.Value))) == matchModeOr {
+				query.mode = matchModeOr
+			}
+			continue
+		}
+
+		name, index, _ := strings.Cut(column, ".")
+		switch name {
 		case "match_field":
-			field = strings.TrimSpace(filter.Value)
+			at(index).field = strings.TrimSpace(filter.Value)
 		case "match_value":
-			value = filter.Value
+			at(index).value = filter.Value
 		case "match_op":
 			switch matchOp(strings.ToLower(strings.TrimSpace(filter.Value))) {
 			case matchOpExists:
-				op = matchOpExists
+				at(index).op = matchOpExists
 			case matchOpMissing:
-				op = matchOpMissing
+				at(index).op = matchOpMissing
+			case matchOpEquals:
+				at(index).op = matchOpEquals
 			}
 		}
 	}
-	return field, value, op
+
+	// Numeric order would need parsing and would change nothing: the conditions
+	// are combined by AND or OR, both commutative. First-seen order keeps the
+	// unnumbered condition first, where the caller put it.
+	for _, index := range order {
+		if byIndex[index].field != "" {
+			query.filters = append(query.filters, *byIndex[index])
+		}
+	}
+	return query
 }
 
 // buildPaginationCursor turns one GetData call's per-partition frontier into the
@@ -1615,15 +1683,37 @@ func lowestConsumedOffsets(rows []map[string]any) map[int32]int64 {
 	return reached
 }
 
-// filterMatches keeps only rows whose JSON value has field == value.
-func filterMatches(rows []map[string]any, field string, value string, op matchOp) []map[string]any {
+// filterMatches keeps only the rows satisfying the query.
+func filterMatches(rows []map[string]any, query matchQuery) []map[string]any {
 	matches := make([]map[string]any, 0, 16)
 	for _, row := range rows {
-		if messageMatchesField(row, field, value, op) {
+		if messageMatchesQuery(row, query) {
 			matches = append(matches, row)
 		}
 	}
 	return matches
+}
+
+// messageMatchesQuery combines the per-field results. An empty query matches
+// everything, which is what "no search" means; it is never reached in practice
+// because an inactive query skips the scan path entirely.
+func messageMatchesQuery(row map[string]any, query matchQuery) bool {
+	if len(query.filters) == 0 {
+		return true
+	}
+	for _, filter := range query.filters {
+		matched := messageMatchesField(row, filter.field, filter.value, filter.op)
+		if query.mode == matchModeOr {
+			if matched {
+				return true
+			}
+			continue
+		}
+		if !matched {
+			return false
+		}
+	}
+	return query.mode != matchModeOr
 }
 
 // messageMatchesField reports whether a message contains a JSON leaf at the

--- a/internal/connector/kafka/topics.go
+++ b/internal/connector/kafka/topics.go
@@ -3,9 +3,11 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kmsg"
 	"github.com/zxchlorka/kizuna/internal/connector"
 )
 
@@ -131,4 +133,85 @@ func maxInt64(left, right int64) int64 {
 		return left
 	}
 	return right
+}
+
+// topicConfig is one broker-reported setting. Source is carried because it
+// answers the question a raw value cannot: whether somebody set this on the
+// topic or whether it is just the broker default showing through.
+type topicConfig struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"`
+	// SetOnTopic is true when the value comes from the topic's own config
+	// rather than from a broker or static default.
+	SetOnTopic bool `json:"set_on_topic"`
+}
+
+func (c *KafkaConnector) topicSchema(ctx context.Context, topic string) (*connector.Schema, error) {
+	ctx, cancel := context.WithTimeout(ctx, metadataTimeout)
+	defer cancel()
+
+	topics, err := c.admin.ListTopics(ctx, topic)
+	if err != nil {
+		return nil, normalizeKafkaError(err)
+	}
+	detail, ok := topics[topic]
+	if !ok || detail.Err != nil {
+		return nil, fmt.Errorf("%w: topic %q not found", connector.ErrRelationNotFound, topic)
+	}
+
+	resources, err := c.admin.DescribeTopicConfigs(ctx, topic)
+	if err != nil {
+		return nil, normalizeKafkaError(err)
+	}
+	resource, err := resources.On(topic, nil)
+	if err != nil {
+		return nil, normalizeKafkaError(err)
+	}
+	if resource.Err != nil {
+		return nil, normalizeKafkaError(resource.Err)
+	}
+
+	configs := make([]topicConfig, 0, len(resource.Configs))
+	for _, config := range resource.Configs {
+		// A sensitive config comes back with a nil value; listing the key with
+		// an empty value would read as "set to nothing" rather than "withheld".
+		if config.Sensitive {
+			continue
+		}
+		configs = append(configs, topicConfig{
+			Key:        config.Key,
+			Value:      config.MaybeValue(),
+			Source:     configSourceName(config.Source),
+			SetOnTopic: config.Source == kmsg.ConfigSourceDynamicTopicConfig,
+		})
+	}
+	sort.Slice(configs, func(i, j int) bool { return configs[i].Key < configs[j].Key })
+
+	return &connector.Schema{
+		ObjectType: "kafka_topic",
+		Columns:    []connector.ColumnMeta{},
+		Meta: map[string]any{
+			"partitions":  len(detail.Partitions),
+			"replication": topicReplicationFactor(detail),
+			"configs":     configs,
+		},
+	}, nil
+}
+
+func configSourceName(source kmsg.ConfigSource) string {
+	switch source {
+	case kmsg.ConfigSourceDynamicTopicConfig:
+		return "topic"
+	case kmsg.ConfigSourceDynamicBrokerConfig:
+		return "broker"
+	case kmsg.ConfigSourceDynamicDefaultBrokerConfig:
+		return "broker default"
+	case kmsg.ConfigSourceStaticBrokerConfig:
+		return "static broker"
+	case kmsg.ConfigSourceDefaultConfig:
+		return "default"
+	default:
+		return "unknown"
+	}
 }

--- a/internal/connector/redis/keys.go
+++ b/internal/connector/redis/keys.go
@@ -94,9 +94,16 @@ func (c *RedisConnector) ListObjectsPage(ctx context.Context, opts connector.Obj
 	truncated := page.nextCursor != ""
 
 	var objects []connector.Object
-	if opts.Path == "" {
+	switch {
+	case opts.Flat:
+		// Every key described under its full name. The tree is assembled from
+		// these on the client, so expanding a namespace costs nothing and the
+		// count on a folder is the number of keys actually behind it rather than
+		// the result of a second, differently-budgeted scan.
+		objects, err = c.describeLeafObjects(ctx, page.keys, func(key string) string { return key }, truncated)
+	case opts.Path == "":
 		objects, err = c.buildRootObjects(ctx, page.keys, truncated)
-	} else {
+	default:
 		objects, err = c.buildNamespaceObjects(ctx, opts.Path, page.keys, truncated)
 	}
 	if err != nil {

--- a/internal/connector/redis/keys.go
+++ b/internal/connector/redis/keys.go
@@ -145,6 +145,17 @@ func treeScanPattern(path, separator, match string) string {
 	if path == "" {
 		return glob
 	}
+	// A filter that already spells out a full key is absolute — the user typed it
+	// against the whole keyspace, in the tree root, to find a namespace too rare
+	// to appear in the first page. Prefixing it with the namespace being opened
+	// would build "fp:fp:*" and the folder found that way would open empty.
+	// Only a bare fragment is relative to the open path.
+	//
+	// Nothing outside the namespace can leak in: buildNamespaceObjects keeps only
+	// keys under path+separator regardless of how wide the pattern is.
+	if strings.Contains(match, separator) {
+		return glob
+	}
 	return path + separator + glob
 }
 

--- a/internal/connector/redis/keys.go
+++ b/internal/connector/redis/keys.go
@@ -41,7 +41,7 @@ func (c *RedisConnector) ListObjects(ctx context.Context, path string) ([]connec
 	deadline := time.Now().Add(legacyTimeBudget)
 
 	for {
-		page, err := c.scanKeysPage(ctx, path, cursor, "")
+		page, err := c.scanKeysPage(ctx, path, cursor, "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func (c *RedisConnector) ListObjects(ctx context.Context, path string) ([]connec
 // ListObjectsPage implements connector.PagedObjectLister: it returns one
 // budgeted slice of the keyspace plus a cursor to continue from.
 func (c *RedisConnector) ListObjectsPage(ctx context.Context, opts connector.ObjectPageOpts) (*connector.ObjectPage, error) {
-	page, err := c.scanKeysPage(ctx, opts.Path, opts.Cursor, opts.Node)
+	page, err := c.scanKeysPage(ctx, opts.Path, opts.Cursor, opts.Node, opts.Match)
 	if err != nil {
 		return nil, err
 	}
@@ -126,11 +126,30 @@ func (b *scanBudget) spent(collected int) bool {
 	return collected >= b.maxKeys || b.scans >= b.maxScans || time.Now().After(b.deadline)
 }
 
-func (c *RedisConnector) scanKeysPage(ctx context.Context, path, cursorToken, node string) (*redisKeyPage, error) {
-	pattern := "*"
-	if path != "" {
-		pattern = path + c.redis.separator + "*"
+// treeScanPattern combines the namespace the tree is showing with the user's
+// filter into one SCAN MATCH glob. The filter is scoped to the open path, so
+// narrowing inside a namespace searches that namespace instead of restarting at
+// the root.
+//
+// A filter with no glob metacharacter is treated as "contains" rather than as
+// an exact key: typing `profile` matching nothing at all would read as a broken
+// filter, and a user who wants an exact key has the key lookup for that.
+func treeScanPattern(path, separator, match string) string {
+	glob := "*"
+	if match != "" {
+		glob = match
+		if !strings.ContainsAny(match, "*?[") {
+			glob = "*" + match + "*"
+		}
 	}
+	if path == "" {
+		return glob
+	}
+	return path + separator + glob
+}
+
+func (c *RedisConnector) scanKeysPage(ctx context.Context, path, cursorToken, node, match string) (*redisKeyPage, error) {
+	pattern := treeScanPattern(path, c.redis.separator, match)
 
 	if c.redis.mode == config.RedisModeCluster {
 		if node != "" {

--- a/internal/connector/redis/keys.go
+++ b/internal/connector/redis/keys.go
@@ -20,9 +20,17 @@ const (
 	// Budget for one ListObjectsPage call. The page ends when any of these is
 	// hit, so a pattern that matches nothing on a huge keyspace still returns
 	// quickly with a cursor instead of iterating the whole database.
-	pageMaxKeys    = 1000
-	pageMaxScans   = 100 // SCAN iterations (~100k examined entries at COUNT 1000)
-	pageTimeBudget = 1500 * time.Millisecond
+	pageMaxKeys = 1000
+	// SCAN iterations at COUNT 1000, so ~400k entries examined. This is what
+	// bounds a selective filter: a pattern matching one key in ten thousand
+	// returns whatever it found in that many entries, not 1000 matches. The
+	// earlier 100 iterations returned a dozen keys on a production keyspace,
+	// which reads as "this pattern is rare" rather than "the scan stopped".
+	pageMaxScans = 400
+	// Kept under the client's 8s request timeout (frontend/src/lib/http.ts) with
+	// room for the round trip, so the budget that ends a page is always the
+	// server's — a client-side abort would lose the cursor with it.
+	pageTimeBudget = 5 * time.Second
 
 	scanBatchCount    = 1000
 	describeChunkSize = 500

--- a/internal/connector/redis/keys_test.go
+++ b/internal/connector/redis/keys_test.go
@@ -267,6 +267,12 @@ func TestTreeScanPattern(t *testing.T) {
 		{name: "root, character class counts as a glob", path: "", match: "dev[iu]ce", want: "dev[iu]ce"},
 		{name: "namespace scopes the filter", path: "profile", match: "2029*", want: "profile:2029*"},
 		{name: "namespace scopes a contains match", path: "profile", match: "2029", want: "profile:*2029*"},
+		// Typed in the root to surface a namespace buried past the first page,
+		// then that namespace is opened. Scoping the pattern again would build
+		// "fp:fp:*" and the folder would open empty.
+		{name: "a full-key filter stays absolute when its namespace opens", path: "fp", match: "fp:*", want: "fp:*"},
+		{name: "a full-key filter with a deeper path stays absolute", path: "fp", match: "fp:1*", want: "fp:1*"},
+		{name: "a separator without a glob is still absolute", path: "fp", match: "fp:", want: "*fp:*"},
 	}
 
 	for _, tt := range tests {

--- a/internal/connector/redis/keys_test.go
+++ b/internal/connector/redis/keys_test.go
@@ -249,3 +249,33 @@ func TestRedisListObjectsPageLeafDescribeUsesPipeline(t *testing.T) {
 		t.Fatalf("unexpected leaf ttl: %#v", leaf.TTLSeconds)
 	}
 }
+
+func TestTreeScanPattern(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		path  string
+		match string
+		want  string
+	}{
+		{name: "root, no filter", path: "", match: "", want: "*"},
+		{name: "namespace, no filter", path: "profile", match: "", want: "profile:*"},
+		{name: "root, plain text is a contains match", path: "", match: "device", want: "*device*"},
+		{name: "root, glob is passed through", path: "", match: "device:*", want: "device:*"},
+		{name: "root, question mark counts as a glob", path: "", match: "dev?ce", want: "dev?ce"},
+		{name: "root, character class counts as a glob", path: "", match: "dev[iu]ce", want: "dev[iu]ce"},
+		{name: "namespace scopes the filter", path: "profile", match: "2029*", want: "profile:2029*"},
+		{name: "namespace scopes a contains match", path: "profile", match: "2029", want: "profile:*2029*"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := treeScanPattern(tt.path, ":", tt.match); got != tt.want {
+				t.Fatalf("treeScanPattern(%q, %q) = %q, want %q", tt.path, tt.match, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/connector/redis/redis.go
+++ b/internal/connector/redis/redis.go
@@ -203,25 +203,39 @@ func (c *RedisConnector) GetInfo(ctx context.Context) (*connector.ConnInfo, erro
 		"master_name": c.redis.masterName,
 	}
 
-	for _, key := range []string{
-		"redis_version", "uptime_in_seconds", "connected_clients", "role",
-		// Memory. maxmemory is 0 when no limit is configured, which the UI
-		// reports as "no limit" rather than as a zero-byte ceiling.
-		"used_memory", "used_memory_human", "used_memory_rss", "used_memory_peak",
-		"maxmemory", "maxmemory_human", "maxmemory_policy", "mem_fragmentation_ratio",
-	} {
+	// Identity and per-node facts. Memory and counts are deliberately NOT taken
+	// from here: INFO answers for whichever node served the connection, and in a
+	// cluster that node's numbers are a fraction of the whole.
+	for _, key := range []string{"redis_version", "uptime_in_seconds", "role", "maxmemory_policy"} {
 		if value, ok := parsed[key]; ok {
 			extra[key] = value
 		}
 	}
 
-	// Reported separately from INFO keyspace, which only ever describes the node
-	// that answered: in cluster mode that is a fraction of the keyspace, and a
-	// silently low total is worse than none at all.
-	if total, err := c.totalKeys(ctx); err != nil {
-		slog.Warn("failed to count redis keys", "error", err)
+	// Totals for the connection. In cluster mode every master is asked and the
+	// results summed; the per-node figures are kept alongside so the screen can
+	// say what one node holds without implying it is the total.
+	if stats, err := c.collectStats(ctx, parsed); err != nil {
+		slog.Warn("failed to collect redis stats", "error", err)
 	} else {
-		extra["total_keys"] = total
+		if stats.keysKnown {
+			extra["total_keys"] = stats.keys
+		}
+		extra["used_memory"] = stats.usedMemory
+		extra["maxmemory"] = stats.maxMemory
+		extra["used_memory_rss"] = stats.rss
+		extra["used_memory_peak"] = stats.peak
+		extra["connected_clients"] = stats.clients
+		extra["node_count"] = stats.nodes
+		if stats.nodes > 1 {
+			extra["node_used_memory"] = stats.usedMemory / int64(stats.nodes)
+			extra["node_maxmemory"] = stats.maxMemory / int64(stats.nodes)
+		}
+		// Reported per node by Redis; over a cluster the honest aggregate is the
+		// ratio of the totals rather than one node's figure.
+		if stats.usedMemory > 0 {
+			extra["mem_fragmentation_ratio"] = fmt.Sprintf("%.2f", float64(stats.rss)/float64(stats.usedMemory))
+		}
 	}
 
 	if c.topology != nil {
@@ -254,36 +268,107 @@ type redisDBSizer interface {
 	DBSize(ctx context.Context) *goredis.IntCmd
 }
 
-// totalKeys counts the keys of the whole connection. In cluster mode that is the
-// sum over the masters, since each node's DBSIZE covers only its own slots.
-func (c *RedisConnector) totalKeys(ctx context.Context) (int64, error) {
+// redisInfoer is the INFO half of a per-node client, probed for alongside
+// redisDBSizer so the SCAN-only fakes in the tests keep compiling.
+type redisInfoer interface {
+	Info(ctx context.Context, sections ...string) *goredis.StringCmd
+}
+
+// clusterStats is what the Overview screen reports about a whole connection.
+// Every field is a total, not a sample: INFO answers for the one node that
+// served the connection, and in a 24-master cluster its 20 GiB of 30 GiB reads
+// as the cluster's when it is one twenty-fourth of it.
+type clusterStats struct {
+	// Masters counted. 1 outside cluster mode.
+	nodes int
+	keys  int64
+	// keysKnown is false when DBSIZE could not be read. Memory still is: a
+	// missing key count must not blank out the rest of the screen.
+	keysKnown  bool
+	usedMemory int64
+	// 0 when no limit is configured, matching Redis's own reporting.
+	maxMemory int64
+	rss       int64
+	peak      int64
+	clients   int64
+}
+
+func statsFromInfo(parsed map[string]string) clusterStats {
+	return clusterStats{
+		nodes:      1,
+		usedMemory: parseRedisInfoInt(parsed, "used_memory"),
+		maxMemory:  parseRedisInfoInt(parsed, "maxmemory"),
+		rss:        parseRedisInfoInt(parsed, "used_memory_rss"),
+		peak:       parseRedisInfoInt(parsed, "used_memory_peak"),
+		clients:    parseRedisInfoInt(parsed, "connected_clients"),
+	}
+}
+
+func parseRedisInfoInt(parsed map[string]string, key string) int64 {
+	value, err := strconv.ParseInt(strings.TrimSpace(parsed[key]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+// collectStats totals the connection. Outside cluster mode that is the INFO
+// already read plus one DBSIZE; in cluster mode every master is asked, because
+// each holds only its own slots and its own share of the memory.
+func (c *RedisConnector) collectStats(ctx context.Context, parsed map[string]string) (clusterStats, error) {
 	if c.redis.mode != config.RedisModeCluster {
-		return c.client.Do(ctx, "DBSIZE").Int64()
+		stats := statsFromInfo(parsed)
+		keys, err := c.client.Do(ctx, "DBSIZE").Int64()
+		if err != nil {
+			slog.Warn("failed to count redis keys", "error", err)
+			return stats, nil
+		}
+		stats.keys = keys
+		stats.keysKnown = true
+		return stats, nil
 	}
 
 	if c.topology == nil {
-		return 0, errors.New("cluster topology is unavailable")
+		return clusterStats{}, errors.New("cluster topology is unavailable")
 	}
 	masters, err := c.topology.Masters(ctx)
 	if err != nil {
-		return 0, err
+		return clusterStats{}, err
 	}
 
-	var total int64
+	total := clusterStats{keysKnown: true}
 	for _, master := range masters {
 		client, err := c.topology.NodeScanClient(master)
 		if err != nil {
-			return 0, err
+			return clusterStats{}, err
 		}
+
 		sizer, ok := client.(redisDBSizer)
 		if !ok {
-			return 0, fmt.Errorf("node %s does not support DBSIZE", master)
+			return clusterStats{}, fmt.Errorf("node %s does not support DBSIZE", master)
 		}
 		size, err := sizer.DBSize(ctx).Result()
 		if err != nil {
-			return 0, err
+			return clusterStats{}, err
 		}
-		total += size
+
+		infoer, ok := client.(redisInfoer)
+		if !ok {
+			return clusterStats{}, fmt.Errorf("node %s does not support INFO", master)
+		}
+		raw, err := infoer.Info(ctx).Result()
+		if err != nil {
+			return clusterStats{}, err
+		}
+
+		node := statsFromInfo(parseRedisInfo(raw))
+		total.nodes++
+		total.keys += size
+		total.usedMemory += node.usedMemory
+		total.maxMemory += node.maxMemory
+		total.rss += node.rss
+		total.peak += node.peak
+		total.clients += node.clients
 	}
 	return total, nil
 }

--- a/internal/connector/redis/redis.go
+++ b/internal/connector/redis/redis.go
@@ -203,10 +203,25 @@ func (c *RedisConnector) GetInfo(ctx context.Context) (*connector.ConnInfo, erro
 		"master_name": c.redis.masterName,
 	}
 
-	for _, key := range []string{"redis_version", "uptime_in_seconds", "connected_clients", "role"} {
+	for _, key := range []string{
+		"redis_version", "uptime_in_seconds", "connected_clients", "role",
+		// Memory. maxmemory is 0 when no limit is configured, which the UI
+		// reports as "no limit" rather than as a zero-byte ceiling.
+		"used_memory", "used_memory_human", "used_memory_rss", "used_memory_peak",
+		"maxmemory", "maxmemory_human", "maxmemory_policy", "mem_fragmentation_ratio",
+	} {
 		if value, ok := parsed[key]; ok {
 			extra[key] = value
 		}
+	}
+
+	// Reported separately from INFO keyspace, which only ever describes the node
+	// that answered: in cluster mode that is a fraction of the keyspace, and a
+	// silently low total is worse than none at all.
+	if total, err := c.totalKeys(ctx); err != nil {
+		slog.Warn("failed to count redis keys", "error", err)
+	} else {
+		extra["total_keys"] = total
 	}
 
 	if c.topology != nil {
@@ -230,6 +245,47 @@ func (c *RedisConnector) GetInfo(ctx context.Context) (*connector.ConnInfo, erro
 		Port:     port,
 		Extra:    extra,
 	}, nil
+}
+
+// redisDBSizer is the DBSIZE half of a per-node client. It is probed for rather
+// than required, so the cluster fakes in the tests — which only need SCAN — stay
+// as they are.
+type redisDBSizer interface {
+	DBSize(ctx context.Context) *goredis.IntCmd
+}
+
+// totalKeys counts the keys of the whole connection. In cluster mode that is the
+// sum over the masters, since each node's DBSIZE covers only its own slots.
+func (c *RedisConnector) totalKeys(ctx context.Context) (int64, error) {
+	if c.redis.mode != config.RedisModeCluster {
+		return c.client.Do(ctx, "DBSIZE").Int64()
+	}
+
+	if c.topology == nil {
+		return 0, errors.New("cluster topology is unavailable")
+	}
+	masters, err := c.topology.Masters(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	var total int64
+	for _, master := range masters {
+		client, err := c.topology.NodeScanClient(master)
+		if err != nil {
+			return 0, err
+		}
+		sizer, ok := client.(redisDBSizer)
+		if !ok {
+			return 0, fmt.Errorf("node %s does not support DBSIZE", master)
+		}
+		size, err := sizer.DBSize(ctx).Result()
+		if err != nil {
+			return 0, err
+		}
+		total += size
+	}
+	return total, nil
 }
 
 func (c *RedisConnector) Close() error {

--- a/internal/connector/redis/redis_test.go
+++ b/internal/connector/redis/redis_test.go
@@ -411,6 +411,11 @@ redis_version:7.2.5
 uptime_in_seconds:1234
 # Clients
 connected_clients:8
+# Memory
+used_memory:1048576
+used_memory_rss:2097152
+maxmemory:4194304
+maxmemory_policy:allkeys-lru
 # Replication
 role:master
 `, nil),
@@ -444,8 +449,26 @@ role:master
 	if info.Port != "6379" {
 		t.Fatalf("unexpected port: %q", info.Port)
 	}
-	if info.Extra["connected_clients"] != "8" {
+	// Reported as a number now, not INFO's raw string: it is summed across the
+	// cluster's masters rather than passed through from one node.
+	if info.Extra["connected_clients"] != int64(8) {
 		t.Fatalf("unexpected connected clients: %#v", info.Extra["connected_clients"])
+	}
+	if info.Extra["used_memory"] != int64(1048576) {
+		t.Fatalf("unexpected used memory: %#v", info.Extra["used_memory"])
+	}
+	if info.Extra["maxmemory"] != int64(4194304) {
+		t.Fatalf("unexpected maxmemory: %#v", info.Extra["maxmemory"])
+	}
+	if info.Extra["maxmemory_policy"] != "allkeys-lru" {
+		t.Fatalf("unexpected policy: %#v", info.Extra["maxmemory_policy"])
+	}
+	if info.Extra["node_count"] != 1 {
+		t.Fatalf("unexpected node count: %#v", info.Extra["node_count"])
+	}
+	// Ratio of the totals, not one node's reported figure.
+	if info.Extra["mem_fragmentation_ratio"] != "2.00" {
+		t.Fatalf("unexpected fragmentation: %#v", info.Extra["mem_fragmentation_ratio"])
 	}
 	if info.Extra["role"] != "master" {
 		t.Fatalf("unexpected role: %#v", info.Extra["role"])


### PR DESCRIPTION
Six requested features, plus the fixes that came out of trying them on real data.

## Redis

**Overview tab** — memory against its configured limit, eviction policy, key count, uptime, clients, fragmentation. Reached from the button next to New CLI.

Every figure is a total for the connection, not for whichever node answered. In cluster mode the masters are walked once for `DBSIZE` and `INFO` and the results summed, with the per-node share shown underneath (`Across 24 masters — 20.5 GiB of 30.4 GiB on each`). Read from one node, a 24-master cluster reported its memory 24x low while the key count beside it was already correct — one truthful number next to an untruthful one, with nothing to tell them apart.

The meter is drawn only against a real ceiling: `maxmemory 0` means Redis enforces none, and a bar at 0% would read as plenty of room for a server that will grow until the host runs out.

**Key tree rebuilt on one scan.** It used to page per level, so opening a folder was its own `SCAN` with its own budget — a folder said `11+ keys` and then showed hundreds. Now one flat page (`flat=1`) comes back with types and TTLs and the client groups it: expanding costs no request, and a folder's count is the keys actually behind it. `Scan more keys` continues from the cursor and appends, deduplicating keys `SCAN` returned twice.

**Filter keys by pattern**, matched by `SCAN MATCH` on the server, so it finds keys never loaded. Plain text is a contains match; anything with `*`, `?` or `[` is passed through as a glob. Budget raised to 5s / 400 iterations — kept under the client's 8s timeout so the cursor is never lost to a client-side abort.

**Pasting into the key lookup trims whitespace.** Selecting a key with the mouse picks up the whitespace between cells, so a paste after a typed prefix landed as `profile: 1234` and matched nothing.

## Kafka

**Topic Config tab** — every broker-reported config, with the source that set it, so a value chosen on the topic is distinguishable from a default that can move under you.

`retention.bytes` is rendered as what Kafka enforces: a per-partition limit, alongside the topic-wide ceiling it implies. A 250 GB setting on a 12-partition topic bounds the topic at 2.73 TiB, not 233 GiB — the reading that prompted this.

**Message search takes several conditions**, combined with AND or OR, edited in a dialog behind a `Filters` button rather than crowding the toolbar. The first condition keeps the existing wire keys and the rest are numbered, so a single-condition request is byte-for-byte what it was.

## Connections

The health status re-checks itself: a forced pass whenever the list opens (a reload, or coming back from a database), then a 30s tick while the tab is in the foreground, stopped when it is hidden and resumed on return. Before this a reload could never re-test — it always landed inside the TTL — so a server that came back stayed red until the per-card button was pressed by hand.

## Verification

Backend behaviour was checked against local containers only, never the production connections in this instance: a 3-master cluster (100 MiB and ~98 keys each → 300 MiB and 300 keys on screen), a 12-partition topic carrying the retention figure above, and 5000 keys across three namespaces (1 request on load, 0 on expand, `Scan more` growing the count with one request).

`go test ./internal/...` and 327 frontend tests pass. New table-driven coverage for the scan pattern, the multi-condition query, byte/duration formatting, retention arithmetic, tree grouping, and the continued scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
