### PR TITLE
Postgres overview: activity, blocking, top queries, tables, replication

### DIFF
--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -122,6 +122,18 @@ export function TabBar({ connId }: TabBarProps) {
           </Button>
         </>
       ) : (
+        <>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-8 shrink-0 gap-1.5 font-mono text-[11px]"
+            onClick={() => openOverviewTab(connId)}
+            title="Show what this server is doing: activity, blocking, top queries, tables"
+          >
+            <Gauge className="h-3.5 w-3.5" />
+            Overview
+          </Button>
         <Button
           type="button"
           size="sm"
@@ -130,9 +142,10 @@ export function TabBar({ connId }: TabBarProps) {
           onClick={() => openSqlTab(connId)}
           title="Open a new SQL console tab"
         >
-          <Plus className="h-3.5 w-3.5" />
-          New SQL
-        </Button>
+            <Plus className="h-3.5 w-3.5" />
+            New SQL
+          </Button>
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/postgres/PostgresOverview.tsx
+++ b/frontend/src/components/postgres/PostgresOverview.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Activity, Database, Gauge, Layers, RefreshCw, Timer } from 'lucide-react'
+import { LoadingSkeleton } from '@/components/LoadingSkeleton'
+import { Button } from '@/components/ui/button'
+import { fetchWithTimeout } from '@/lib/http'
+import { cn } from '@/lib/utils'
+import { useConnectionStore } from '@/stores/connections'
+import type { ColumnMeta } from '@/types/api'
+
+interface PostgresOverviewProps {
+  connId: string
+}
+
+type Section = 'activity' | 'statements' | 'tables' | 'replication'
+
+interface StatsResult {
+  columns: ColumnMeta[]
+  rows: Array<Record<string, unknown>>
+  meta?: { hint?: string }
+}
+
+const sections: Array<{ id: Section; label: string; icon: typeof Activity; blurb: string }> = [
+  {
+    id: 'activity',
+    label: 'Activity',
+    icon: Activity,
+    blurb:
+      'Sessions doing something, blocked ones first. A session idle inside a transaction runs nothing while holding locks and keeping autovacuum out.',
+  },
+  {
+    id: 'statements',
+    label: 'Top queries',
+    icon: Timer,
+    blurb:
+      'Ordered by total time, not by how slow one call looks: a 3 ms query run ten million times is the one worth finding.',
+  },
+  {
+    id: 'tables',
+    label: 'Tables',
+    icon: Layers,
+    blurb: 'Size next to neglect — a large table autovacuum has not visited explains a lot of mysteries.',
+  },
+  {
+    id: 'replication',
+    label: 'Replication',
+    icon: Gauge,
+    blurb: 'How far each replica is behind, in bytes and in time. Bytes say how much, time says how long.',
+  },
+]
+
+// Numbers are right-aligned so magnitudes line up in a monospace column; the
+// query text is the only column that wants the full width it can get.
+function alignFor(name: string): string {
+  if (name === 'query') return 'text-left'
+  return /(_ms|_rows|_pct|calls|rows|pid)$/.test(name) ? 'text-right tabular-nums' : 'text-left'
+}
+
+function renderCell(value: unknown): string {
+  if (value === null || value === undefined) return '—'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+export function PostgresOverview({ connId }: PostgresOverviewProps) {
+  const connection = useConnectionStore((state) => state.connections.find((item) => item.id === connId))
+  const [section, setSection] = useState<Section>('activity')
+  const [result, setResult] = useState<StatsResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    setResult(null)
+    try {
+      const res = await fetchWithTimeout(`/api/connections/${connId}/stats?section=${section}`)
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: res.statusText }))
+        throw new Error(body.error || 'Failed to load server statistics')
+      }
+      setResult((await res.json()) as StatsResult)
+    } catch (loadError) {
+      setError((loadError as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }, [connId, section])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const active = sections.find((item) => item.id === section)
+
+  return (
+    <div className="flex-1 overflow-auto p-4">
+      <div className="mx-auto flex max-w-6xl flex-col gap-3">
+        <div className="rounded-sm border border-border bg-card p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-sm border border-blue-500/30 bg-blue-500/5">
+                <Database className="h-5 w-5 text-blue-500" />
+              </div>
+              <div className="min-w-0">
+                <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Postgres overview</div>
+                <div className="mt-1 truncate font-mono text-lg">{connection?.name ?? connId}</div>
+              </div>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 shrink-0 gap-1.5 font-mono text-[11px]"
+              disabled={loading}
+              onClick={() => void load()}
+            >
+              <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+              Refresh
+            </Button>
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-1">
+            {sections.map(({ id, label, icon: Icon }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setSection(id)}
+                // Named for assistive tech because the sidebar carries a tree
+                // filter with the same word on it.
+                aria-label={`${label} section`}
+                aria-pressed={section === id}
+                className={cn(
+                  'flex items-center gap-1.5 rounded-sm border px-2.5 py-1.5 font-mono text-[11px] transition-colors',
+                  section === id
+                    ? 'border-blue-500/40 bg-blue-500/5 text-blue-600 dark:text-blue-400'
+                    : 'border-transparent text-muted-foreground hover:bg-muted'
+                )}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {active && <div className="px-1 font-mono text-[11px] leading-relaxed text-muted-foreground">{active.blurb}</div>}
+
+        {loading && <LoadingSkeleton variant="table" />}
+
+        {!loading && error && (
+          <div className="rounded-sm border border-destructive/40 bg-destructive/5 px-3 py-3 font-mono text-xs leading-relaxed text-destructive">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && result && (
+          <div className="rounded-sm border border-border">
+            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+              <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                {result.rows.length} {result.rows.length === 1 ? 'row' : 'rows'}
+              </div>
+              {/* The scope of the numbers travels with them: a figure that does
+                  not say what it covers is the one that gets misread. */}
+              {result.meta?.hint && (
+                <div className="font-mono text-[11px] text-muted-foreground">{result.meta.hint}</div>
+              )}
+            </div>
+
+            {result.rows.length === 0 ? (
+              <div className="px-3 py-8 text-center font-mono text-xs text-muted-foreground">
+                Nothing to report right now.
+              </div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full font-mono text-xs">
+                  <thead>
+                    <tr className="border-b border-border text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                      {result.columns.map((column) => (
+                        <th key={column.name} className={cn('px-3 py-2 font-normal', alignFor(column.name))}>
+                          {column.name}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {result.rows.map((row, index) => (
+                      <tr key={index} className="border-b border-border/50 last:border-b-0 hover:bg-muted/40">
+                        {result.columns.map((column) => (
+                          <td
+                            key={column.name}
+                            className={cn(
+                              'px-3 py-1.5 align-top',
+                              alignFor(column.name),
+                              column.name === 'query' && 'whitespace-pre-wrap break-words',
+                              // A blocked session is the reason this screen was
+                              // opened; it should not need hunting for.
+                              column.name === 'blocked_by' && row[column.name] ? 'text-amber-600 dark:text-amber-400' : ''
+                            )}
+                          >
+                            {renderCell(row[column.name])}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/DataViewPage.tsx
+++ b/frontend/src/pages/DataViewPage.tsx
@@ -14,6 +14,7 @@ import { PgTableView } from '@/components/PgTableView'
 import { SqlConsole } from '@/components/SqlConsole/SqlConsole'
 import { RedisCli } from '@/components/redis/RedisCli/RedisCli'
 import { RedisOverview } from '@/components/redis/RedisOverview'
+import { PostgresOverview } from '@/components/postgres/PostgresOverview'
 import { KafkaTopicView } from '@/components/kafka/KafkaTopicView'
 import { isRedisObjectType } from '@/lib/objectTypes'
 import { isConnectionHealthStale, useConnectionHealthStore } from '@/stores/connectionHealth'
@@ -134,7 +135,11 @@ export default function DataViewPage() {
               ) : activeTab.kind === 'redis-cli' ? (
                 <RedisCli tabId={activeTab.id} connId={activeTab.connId} />
               ) : activeTab.kind === 'overview' ? (
-                <RedisOverview connId={activeTab.connId} />
+                currentConnection?.type === 'postgres' ? (
+                  <PostgresOverview connId={activeTab.connId} />
+                ) : (
+                  <RedisOverview connId={activeTab.connId} />
+                )
               ) : activeTab.objectType === 'index' ? (
                 <IndexInspectorView
                   connId={activeTab.connId}

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -349,6 +349,39 @@ func (h *ConnectionsHandler) Info(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, info)
 }
 
+// ServerStats reports what the server itself is doing. Only connectors that can
+// answer implement the capability; the rest say so rather than returning an
+// empty result that reads as "nothing to report".
+func (h *ConnectionsHandler) ServerStats(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	section := connector.ServerStatsSection(r.URL.Query().Get("section"))
+	if section == "" {
+		writeError(w, http.StatusBadRequest, "section is required")
+		return
+	}
+
+	c, cancel, err := getConnector(r.Context(), h.manager, id)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+	defer cancel()
+
+	provider, ok := c.(connector.ServerStatsProvider)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "server statistics are not available for this connection type")
+		return
+	}
+
+	result, err := provider.ServerStats(r.Context(), section)
+	if err != nil {
+		writeConnectorError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
 func generateID() string {
 	b := make([]byte, 16)
 	_, _ = rand.Read(b)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -41,6 +41,7 @@ func NewRouter(cfg *config.AppConfig, manager *connector.ConnectionManager) chi.
 			r.Delete("/", connHandler.Delete)
 			r.Post("/test", connHandler.Test)
 			r.Get("/info", connHandler.Info)
+			r.Get("/stats", connHandler.ServerStats)
 			r.Get("/databases", connHandler.Databases)
 			r.Post("/duplicate", connHandler.Duplicate)
 			r.Get("/objects", objHandler.ListObjects)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -68,6 +68,33 @@ type PagedObjectLister interface {
 	ListObjectsPage(ctx context.Context, opts ObjectPageOpts) (*ObjectPage, error)
 }
 
+// ServerStatsSection names one view of what a server is doing right now.
+type ServerStatsSection string
+
+const (
+	// StatsActivity: running queries, what blocks what, and connections left
+	// open inside a transaction.
+	StatsActivity ServerStatsSection = "activity"
+	// StatsStatements: the workload by cost, from pg_stat_statements.
+	StatsStatements ServerStatsSection = "statements"
+	// StatsTables: size, dead tuples and when autovacuum last ran.
+	StatsTables ServerStatsSection = "tables"
+	// StatsReplication: how far each replica is behind.
+	StatsReplication ServerStatsSection = "replication"
+)
+
+// ServerStatsProvider is an optional capability for connectors that can report
+// what the server itself is doing, as opposed to what is stored in it.
+//
+// Each section answers in the same shape the data grid already renders, so the
+// screen showing them needs no per-section table code. A section the server
+// cannot answer — an extension that is not installed, a role without the
+// privilege to see other sessions — must come back as a plain error explaining
+// which, not as an empty table that reads as "nothing is happening".
+type ServerStatsProvider interface {
+	ServerStats(ctx context.Context, section ServerStatsSection) (*DataResult, error)
+}
+
 // SQLCatalogColumn is one column of a table in the SQL catalog snapshot.
 type SQLCatalogColumn struct {
 	Name string `json:"name"`

--- a/internal/connector/postgres/stats.go
+++ b/internal/connector/postgres/stats.go
@@ -1,0 +1,209 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/zxchlorka/kizuna/internal/connector"
+)
+
+// Server introspection is read-only and cheap, but it runs against a live
+// server that may already be struggling — which is exactly when someone opens
+// this screen. Every section is capped and deadlined so the diagnosis can never
+// become part of the problem.
+const (
+	statsTimeout = 5 * time.Second
+	statsMaxRows = 200
+)
+
+// SQLSTATEs that mean "the server can answer this, you may not ask" or "this
+// server has no such thing" — both need naming rather than an empty table.
+const (
+	sqlStateInsufficientPrivilege = "42501"
+	sqlStateUndefinedTable        = "42P01"
+	sqlStateUndefinedFunction     = "42883"
+)
+
+// ServerStats implements connector.ServerStatsProvider.
+func (p *PostgresConnector) ServerStats(ctx context.Context, section connector.ServerStatsSection) (*connector.DataResult, error) {
+	query, ok := statsQueries[section]
+	if !ok {
+		return nil, fmt.Errorf("%w: unknown stats section %q", connector.ErrBadRequest, section)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, statsTimeout)
+	defer cancel()
+
+	result, err := p.queryStats(ctx, query.sql)
+	if err != nil {
+		return nil, explainStatsError(section, err)
+	}
+	result.Meta = map[string]any{"section": string(section), "hint": query.hint}
+	return result, nil
+}
+
+type statsQuery struct {
+	sql string
+	// hint travels with the rows and says what the numbers do NOT cover, so a
+	// figure is never read as broader than it is.
+	hint string
+}
+
+// queryStats runs one introspection query and shapes whatever it returns into
+// the grid's format. Columns come from the result description rather than a
+// hand-written list, so a query and its display can never drift apart.
+func (p *PostgresConnector) queryStats(ctx context.Context, sql string) (*connector.DataResult, error) {
+	rows, err := p.pool.Query(ctx, sql)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	columns := make([]connector.ColumnMeta, 0, len(rows.FieldDescriptions()))
+	for _, field := range rows.FieldDescriptions() {
+		columns = append(columns, connector.ColumnMeta{Name: field.Name, DataType: "text", Nullable: true})
+	}
+
+	resultRows := make([]map[string]any, 0, 32)
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		resultRows = append(resultRows, buildResultRow(columns, values))
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &connector.DataResult{
+		Columns: columns,
+		Rows:    resultRows,
+		Total:   int64(len(resultRows)),
+		HasMore: len(resultRows) >= statsMaxRows,
+	}, nil
+}
+
+// explainStatsError turns the two failures that are about the server's setup
+// rather than about the query into something actionable. Postgres reports both
+// as ordinary SQL errors, and "relation pg_stat_statements does not exist" does
+// not tell a reader that an extension is missing, let alone which.
+func explainStatsError(section connector.ServerStatsSection, err error) error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return normalizePostgresError(err)
+	}
+
+	switch pgErr.Code {
+	case sqlStateUndefinedTable, sqlStateUndefinedFunction:
+		if section == connector.StatsStatements {
+			return fmt.Errorf(
+				"%w: pg_stat_statements is not installed on this server. It has to be listed in "+
+					"shared_preload_libraries and created with CREATE EXTENSION pg_stat_statements",
+				connector.ErrBadRequest)
+		}
+		return normalizePostgresError(err)
+	case sqlStateInsufficientPrivilege:
+		return fmt.Errorf(
+			"%w: this role may not read server-wide statistics. Granting pg_monitor "+
+				"(or pg_read_all_stats) lets it see sessions and statements other than its own",
+			connector.ErrForbidden)
+	default:
+		return normalizePostgresError(err)
+	}
+}
+
+var statsQueries = map[connector.ServerStatsSection]statsQuery{
+	// Activity answers "what is happening right now, and what is stuck behind
+	// what". Idle-in-transaction sessions are included deliberately: they look
+	// harmless because they are running nothing, while holding locks and keeping
+	// autovacuum from cleaning up behind them.
+	connector.StatsActivity: {
+		hint: "Sessions on this server. A limited role sees only its own.",
+		sql: `
+			SELECT a.pid,
+			       a.state,
+			       a.usename                                   AS "user",
+			       a.application_name                          AS application,
+			       a.client_addr::text                         AS client,
+			       date_trunc('second', now() - a.state_change)::text AS in_state,
+			       date_trunc('second', now() - a.xact_start)::text   AS in_transaction,
+			       a.wait_event_type                            AS wait_type,
+			       a.wait_event,
+			       NULLIF(array_to_string(pg_blocking_pids(a.pid), ', '), '') AS blocked_by,
+			       left(regexp_replace(a.query, '\s+', ' ', 'g'), 200) AS query
+			FROM pg_stat_activity a
+			WHERE a.pid <> pg_backend_pid()
+			  AND a.backend_type = 'client backend'
+			  AND a.state IS NOT NULL
+			  AND a.state <> 'idle'
+			ORDER BY (pg_blocking_pids(a.pid) <> '{}') DESC,
+			         a.xact_start NULLS LAST
+			LIMIT 200`,
+	},
+
+	// The workload by cost. Ordered by total time rather than by mean: a query
+	// taking 3ms and running ten million times is the one worth finding, and it
+	// never surfaces in a list ordered by how slow a single call looks.
+	connector.StatsStatements: {
+		hint: "Since the last pg_stat_statements reset, not since server start.",
+		sql: `
+			SELECT round(s.total_exec_time)::bigint            AS total_ms,
+			       s.calls,
+			       round(s.mean_exec_time::numeric, 2)         AS mean_ms,
+			       round(s.max_exec_time)::bigint              AS max_ms,
+			       s.rows,
+			       round(100 * s.total_exec_time
+			             / NULLIF(sum(s.total_exec_time) OVER (), 0))::int AS pct_time,
+			       left(regexp_replace(s.query, '\s+', ' ', 'g'), 300)     AS query
+			FROM pg_stat_statements s
+			ORDER BY s.total_exec_time DESC
+			LIMIT 200`,
+	},
+
+	// Size and neglect side by side. A table is rarely interesting for its size
+	// alone; it becomes interesting when it is large AND autovacuum has not been
+	// near it, which is the pair that explains a slow table nobody changed.
+	connector.StatsTables: {
+		hint: "Dead-tuple counts are estimates maintained by the statistics collector.",
+		sql: `
+			SELECT s.schemaname || '.' || s.relname                       AS "table",
+			       pg_size_pretty(pg_total_relation_size(c.oid))          AS total,
+			       pg_size_pretty(pg_table_size(c.oid))                   AS data,
+			       pg_size_pretty(pg_indexes_size(c.oid))                 AS indexes,
+			       s.n_live_tup                                           AS live_rows,
+			       s.n_dead_tup                                           AS dead_rows,
+			       CASE WHEN s.n_live_tup > 0
+			            THEN round(100.0 * s.n_dead_tup / s.n_live_tup)::int
+			       END                                                    AS dead_pct,
+			       date_trunc('second', GREATEST(s.last_autovacuum, s.last_vacuum)) AS last_vacuum,
+			       date_trunc('second', GREATEST(s.last_autoanalyze, s.last_analyze)) AS last_analyze
+			FROM pg_stat_user_tables s
+			JOIN pg_class c ON c.oid = s.relid
+			ORDER BY pg_total_relation_size(c.oid) DESC
+			LIMIT 200`,
+	},
+
+	// Replication lag in bytes and in time. Bytes answer "how far behind", the
+	// time columns answer "how long behind" — a replica can be a few megabytes
+	// behind for a second or for an hour, and only the second one is an outage.
+	connector.StatsReplication: {
+		hint: "Rows appear on a primary with connected replicas; a replica reports none.",
+		sql: `
+			SELECT r.application_name                       AS replica,
+			       r.client_addr::text                      AS client,
+			       r.state,
+			       r.sync_state,
+			       pg_size_pretty(
+			           pg_wal_lsn_diff(pg_current_wal_lsn(), r.replay_lsn)) AS behind,
+			       date_trunc('second', r.write_lag)::text  AS write_lag,
+			       date_trunc('second', r.flush_lag)::text  AS flush_lag,
+			       date_trunc('second', r.replay_lag)::text AS replay_lag
+			FROM pg_stat_replication r
+			ORDER BY pg_wal_lsn_diff(pg_current_wal_lsn(), r.replay_lsn) DESC
+			LIMIT 200`,
+	},
+}

--- a/internal/connector/postgres/stats_test.go
+++ b/internal/connector/postgres/stats_test.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/zxchlorka/kizuna/internal/connector"
+)
+
+// A section that fails because of how the server is set up must say which
+// setup: an empty table, or Postgres's own "relation does not exist", tells the
+// reader nothing they can act on.
+func TestExplainStatsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		section connector.ServerStatsSection
+		err     error
+		wantIs  error
+		wantSub string
+	}{
+		{
+			name:    "missing extension names the extension",
+			section: connector.StatsStatements,
+			err:     &pgconn.PgError{Code: sqlStateUndefinedTable, Message: `relation "pg_stat_statements" does not exist`},
+			wantIs:  connector.ErrBadRequest,
+			wantSub: "shared_preload_libraries",
+		},
+		{
+			name:    "denied privilege names the role to grant",
+			section: connector.StatsActivity,
+			err:     &pgconn.PgError{Code: sqlStateInsufficientPrivilege, Message: "permission denied"},
+			wantIs:  connector.ErrForbidden,
+			wantSub: "pg_monitor",
+		},
+		{
+			// Only pg_stat_statements is an extension; a missing relation in any
+			// other section is a real fault and must not be dressed up as one.
+			name:    "a missing relation elsewhere is not blamed on an extension",
+			section: connector.StatsTables,
+			err:     &pgconn.PgError{Code: sqlStateUndefinedTable, Message: `relation "nope" does not exist`},
+			wantSub: "nope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := explainStatsError(tt.section, tt.err)
+			if got == nil {
+				t.Fatal("expected an error")
+			}
+			if tt.wantIs != nil && !errors.Is(got, tt.wantIs) {
+				t.Fatalf("error = %v, want one wrapping %v", got, tt.wantIs)
+			}
+			if !strings.Contains(got.Error(), tt.wantSub) {
+				t.Fatalf("error %q does not mention %q", got, tt.wantSub)
+			}
+		})
+	}
+}
+
+// Every declared section must have a query behind it, or the screen offers a tab
+// that can only fail.
+func TestEverySectionHasAQuery(t *testing.T) {
+	t.Parallel()
+
+	for _, section := range []connector.ServerStatsSection{
+		connector.StatsActivity, connector.StatsStatements,
+		connector.StatsTables, connector.StatsReplication,
+	} {
+		query, ok := statsQueries[section]
+		if !ok {
+			t.Fatalf("section %q has no query", section)
+		}
+		if query.hint == "" {
+			t.Fatalf("section %q has no hint saying what its numbers do not cover", section)
+		}
+	}
+}


### PR DESCRIPTION
Postgres gets the screen Redis already had — but about what the server is *doing*, not what is stored in it. Four sections behind one new capability.

**Activity.** Sessions that are doing something, blocked ones sorted first, with `blocked_by` naming the session that holds the lock. Sessions idle inside a transaction are included on purpose: they look harmless because they are running nothing, while holding locks and keeping autovacuum out.

**Top queries.** `pg_stat_statements` ordered by total time rather than by mean — a 3 ms query run ten million times is the one worth finding, and it never surfaces in a list sorted by how slow a single call looks.

**Tables.** Size split into data, indexes and total, next to dead tuples and when autovacuum last ran. Size alone is rarely interesting; large *and* unvisited is the pair that explains a slow table nobody changed.

**Replication.** How far each replica is behind, in bytes and in time. Bytes say how much, the lag columns say how long — a replica can be megabytes behind for a second or for an hour, and only one of those is an outage.

### Failures that are about setup, not about the query

Postgres reports a missing extension as `relation "pg_stat_statements" does not exist`, which does not tell a reader that an extension is missing, let alone which. Those two cases are named instead:

- extension absent → what to add to `shared_preload_libraries` and what to `CREATE`
- privilege denied → that `pg_monitor` (or `pg_read_all_stats`) is what lets a role see sessions other than its own

Every section also carries a hint stating what its numbers do *not* cover — statements are since the last reset, activity is only what this role may see. A figure that does not say what it covers is the one that gets misread; this session produced two such bugs already.

### Shape

`ServerStatsProvider` is optional, like `PagedObjectLister`: only Postgres implements it, and connectors that do not say so rather than returning an empty table. Sections answer in the grid's own `DataResult` shape, so the screen needs no per-section table code and a query cannot drift from its display — columns come from the result description.

Queries are capped at 200 rows with a 5s deadline. This screen gets opened when a server is already struggling; the diagnosis must not join the problem.

### Verification

Against local containers: a real lock conflict between two sessions (`blocked_by` resolved to the holding pid, blocked row sorted first), a table left with 50% dead tuples, a server started with `shared_preload_libraries=pg_stat_statements` for the statements section, and a server without it for the error path. Go tests cover both error explanations and that every declared section has a query and a hint.
