### PR TITLE
Fallback chains, cluster masters, unused indexes and sequence headroom

### DIFF
--- a/frontend/src/components/kafka/KafkaTopicConfig.tsx
+++ b/frontend/src/components/kafka/KafkaTopicConfig.tsx
@@ -10,11 +10,18 @@ interface KafkaTopicConfigProps {
   topic: string
 }
 
+interface TopicConfigFallback {
+  key: string
+  value: string
+  source: string
+}
+
 interface TopicConfigEntry {
   key: string
   value: string
   source: string
   set_on_topic: boolean
+  fallbacks?: TopicConfigFallback[]
 }
 
 interface TopicSchema {
@@ -110,6 +117,7 @@ export function KafkaTopicConfig({ connId, topic }: KafkaTopicConfigProps) {
                 <th className="px-3 py-2 text-left font-normal">Key</th>
                 <th className="px-3 py-2 text-left font-normal">Value</th>
                 <th className="px-3 py-2 text-left font-normal">Set by</th>
+                <th className="px-3 py-2 text-left font-normal">Without the override</th>
               </tr>
             </thead>
             <tbody>
@@ -127,11 +135,22 @@ export function KafkaTopicConfig({ connId, topic }: KafkaTopicConfigProps) {
                   >
                     {config.source}
                   </td>
+                  {/* What this setting falls back to. A value set on the topic
+                      says nothing about what the cluster would apply without it,
+                      or which broker setting to change for every topic at once. */}
+                  <td className="px-3 py-1.5 align-top text-muted-foreground">
+                    {config.fallbacks && config.fallbacks.length > 0
+                      ? config.fallbacks
+                          .filter((fallback) => fallback.source !== config.source)
+                          .map((fallback) => `${fallback.key} = ${fallback.value || '—'} (${fallback.source})`)
+                          .join(' · ') || '—'
+                      : '—'}
+                  </td>
                 </tr>
               ))}
               {configs.length === 0 && (
                 <tr>
-                  <td colSpan={3} className="px-3 py-6 text-center text-muted-foreground">
+                  <td colSpan={4} className="px-3 py-6 text-center text-muted-foreground">
                     The broker reported no configs for this topic.
                   </td>
                 </tr>

--- a/frontend/src/components/postgres/PostgresOverview.tsx
+++ b/frontend/src/components/postgres/PostgresOverview.tsx
@@ -16,7 +16,7 @@ type Section = 'activity' | 'statements' | 'tables' | 'replication' | 'indexes' 
 interface StatsResult {
   columns: ColumnMeta[]
   rows: Array<Record<string, unknown>>
-  meta?: { hint?: string }
+  meta?: { hint?: string; notice?: string }
 }
 
 const sections: Array<{ id: Section; label: string; icon: typeof Activity; blurb: string }> = [
@@ -179,6 +179,15 @@ export function PostgresOverview({ connId }: PostgresOverviewProps) {
                 <div className="font-mono text-[11px] text-muted-foreground">{result.meta.hint}</div>
               )}
             </div>
+
+            {/* Raised above the table, not tucked into the header: a wall of
+                "<insufficient privilege>" needs its explanation before the rows,
+                not beside them. */}
+            {result.meta?.notice && (
+              <div className="border-b border-amber-500/30 bg-amber-500/5 px-3 py-2 font-mono text-[11px] leading-relaxed text-amber-600 dark:text-amber-400">
+                {result.meta.notice}
+              </div>
+            )}
 
             {result.rows.length === 0 ? (
               <div className="px-3 py-8 text-center font-mono text-xs text-muted-foreground">

--- a/frontend/src/components/postgres/PostgresOverview.tsx
+++ b/frontend/src/components/postgres/PostgresOverview.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Activity, Database, Gauge, Layers, RefreshCw, Timer, Unplug } from 'lucide-react'
+import { Activity, Database, Gauge, Hash, Layers, RefreshCw, Timer, Unplug } from 'lucide-react'
 import { LoadingSkeleton } from '@/components/LoadingSkeleton'
 import { Button } from '@/components/ui/button'
 import { fetchWithTimeout } from '@/lib/http'
@@ -11,7 +11,7 @@ interface PostgresOverviewProps {
   connId: string
 }
 
-type Section = 'activity' | 'statements' | 'tables' | 'replication' | 'indexes'
+type Section = 'activity' | 'statements' | 'tables' | 'replication' | 'indexes' | 'sequences'
 
 interface StatsResult {
   columns: ColumnMeta[]
@@ -46,6 +46,13 @@ const sections: Array<{ id: Section; label: string; icon: typeof Activity; blurb
     icon: Unplug,
     blurb:
       'Indexes nothing has read, largest first — each still costs a write on every insert and holds its disk. A zero right after a statistics reset means unknown, not unused.',
+  },
+  {
+    id: 'sequences',
+    label: 'Sequences',
+    icon: Hash,
+    blurb:
+      'Headroom against the ceiling of the column each sequence feeds. An integer column stops at 2 147 483 647 and inserts simply begin to fail.',
   },
   {
     id: 'replication',

--- a/frontend/src/components/postgres/PostgresOverview.tsx
+++ b/frontend/src/components/postgres/PostgresOverview.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Activity, Database, Gauge, Layers, RefreshCw, Timer } from 'lucide-react'
+import { Activity, Database, Gauge, Layers, RefreshCw, Timer, Unplug } from 'lucide-react'
 import { LoadingSkeleton } from '@/components/LoadingSkeleton'
 import { Button } from '@/components/ui/button'
 import { fetchWithTimeout } from '@/lib/http'
@@ -11,7 +11,7 @@ interface PostgresOverviewProps {
   connId: string
 }
 
-type Section = 'activity' | 'statements' | 'tables' | 'replication'
+type Section = 'activity' | 'statements' | 'tables' | 'replication' | 'indexes'
 
 interface StatsResult {
   columns: ColumnMeta[]
@@ -41,6 +41,13 @@ const sections: Array<{ id: Section; label: string; icon: typeof Activity; blurb
     blurb: 'Size next to neglect — a large table autovacuum has not visited explains a lot of mysteries.',
   },
   {
+    id: 'indexes',
+    label: 'Unused indexes',
+    icon: Unplug,
+    blurb:
+      'Indexes nothing has read, largest first — each still costs a write on every insert and holds its disk. A zero right after a statistics reset means unknown, not unused.',
+  },
+  {
     id: 'replication',
     label: 'Replication',
     icon: Gauge,
@@ -52,7 +59,7 @@ const sections: Array<{ id: Section; label: string; icon: typeof Activity; blurb
 // query text is the only column that wants the full width it can get.
 function alignFor(name: string): string {
   if (name === 'query') return 'text-left'
-  return /(_ms|_rows|_pct|calls|rows|pid)$/.test(name) ? 'text-right tabular-nums' : 'text-left'
+  return /(_ms|_rows|_pct|_used|_value|calls|rows|pid|scans|size)$/.test(name) ? 'text-right tabular-nums' : 'text-left'
 }
 
 function renderCell(value: unknown): string {

--- a/frontend/src/components/redis/RedisOverview.tsx
+++ b/frontend/src/components/redis/RedisOverview.tsx
@@ -11,6 +11,14 @@ interface RedisOverviewProps {
   connId: string
 }
 
+interface RedisNodeStat {
+  address: string
+  keys: number
+  used_memory: number
+  maxmemory: number
+  connected_clients: number
+}
+
 // INFO reports every field as a string; a missing field and an unparseable one
 // are the same thing here — a number we do not have and must not invent.
 function num(extra: Record<string, unknown> | undefined, key: string): number | null {
@@ -133,6 +141,7 @@ export function RedisOverview({ connId }: RedisOverviewProps) {
   // same screen used to show one node's 20 GiB of 30 GiB as though it were the
   // whole cluster's — which on 24 masters understated it twenty-four fold.
   const clusterNote = nodes > 1 ? `Summed across ${nodes} masters` : undefined
+  const nodeRows = Array.isArray(extra?.nodes) ? (extra.nodes as RedisNodeStat[]) : []
 
   return (
     <div className="flex-1 overflow-auto p-4">
@@ -241,6 +250,65 @@ export function RedisOverview({ connId }: RedisOverviewProps) {
                 fragmentation !== null && fragmentation > 1.5 ? 'More RSS than data' : undefined
               )}
             </div>
+
+            {nodeRows.length > 0 && (
+              <div className="rounded-sm border border-border">
+                <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2">
+                  <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    Masters ({nodeRows.length})
+                  </div>
+                  <div className="font-mono text-[11px] text-muted-foreground">
+                    What each holds. The totals above cannot show an uneven one.
+                  </div>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full font-mono text-xs">
+                    <thead>
+                      <tr className="border-b border-border text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                        <th className="px-3 py-2 text-left font-normal">Node</th>
+                        <th className="px-3 py-2 text-right font-normal">Keys</th>
+                        <th className="px-3 py-2 text-right font-normal">Used</th>
+                        <th className="px-3 py-2 text-right font-normal">Limit</th>
+                        <th className="px-3 py-2 text-right font-normal">Used %</th>
+                        <th className="px-3 py-2 text-right font-normal">Clients</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {nodeRows.map((node) => {
+                        const pct = node.maxmemory > 0 ? (100 * node.used_memory) / node.maxmemory : null
+                        return (
+                          <tr key={node.address} className="border-b border-border/50 last:border-b-0">
+                            <td className="px-3 py-1.5">{node.address}</td>
+                            <td className="px-3 py-1.5 text-right tabular-nums">{formatExactCount(node.keys)}</td>
+                            <td className="px-3 py-1.5 text-right tabular-nums">{formatBytes(node.used_memory)}</td>
+                            <td className="px-3 py-1.5 text-right tabular-nums">
+                              {node.maxmemory > 0 ? formatBytes(node.maxmemory) : 'none'}
+                            </td>
+                            {/* The node that will hit its ceiling first is the
+                                one this table exists to surface. */}
+                            <td
+                              className={cn(
+                                'px-3 py-1.5 text-right tabular-nums',
+                                pct !== null && pct >= 90
+                                  ? 'text-red-600 dark:text-red-400'
+                                  : pct !== null && pct >= 75
+                                    ? 'text-orange-600 dark:text-orange-400'
+                                    : ''
+                              )}
+                            >
+                              {pct === null ? '—' : `${pct.toFixed(1)}%`}
+                            </td>
+                            <td className="px-3 py-1.5 text-right tabular-nums">
+                              {formatExactCount(node.connected_clients)}
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -83,6 +83,8 @@ const (
 	StatsReplication ServerStatsSection = "replication"
 	// StatsIndexes: indexes nothing has read, with what they cost to keep.
 	StatsIndexes ServerStatsSection = "indexes"
+	// StatsSequences: sequences approaching the ceiling of the column they feed.
+	StatsSequences ServerStatsSection = "sequences"
 )
 
 // ServerStatsProvider is an optional capability for connectors that can report

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -81,6 +81,8 @@ const (
 	StatsTables ServerStatsSection = "tables"
 	// StatsReplication: how far each replica is behind.
 	StatsReplication ServerStatsSection = "replication"
+	// StatsIndexes: indexes nothing has read, with what they cost to keep.
+	StatsIndexes ServerStatsSection = "indexes"
 )
 
 // ServerStatsProvider is an optional capability for connectors that can report

--- a/internal/connector/kafka/topics.go
+++ b/internal/connector/kafka/topics.go
@@ -145,6 +145,17 @@ type topicConfig struct {
 	// SetOnTopic is true when the value comes from the topic's own config
 	// rather than from a broker or static default.
 	SetOnTopic bool `json:"set_on_topic"`
+	// Fallbacks is what this setting would be without the override above it, in
+	// order of preference. It answers the question a bare "set on the topic"
+	// cannot: what the cluster would apply if the override were dropped, and
+	// under which broker setting to go change it for everyone.
+	Fallbacks []topicConfigFallback `json:"fallbacks,omitempty"`
+}
+
+type topicConfigFallback struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Source string `json:"source"`
 }
 
 func (c *KafkaConnector) topicSchema(ctx context.Context, topic string) (*connector.Schema, error) {
@@ -179,11 +190,30 @@ func (c *KafkaConnector) topicSchema(ctx context.Context, topic string) (*connec
 		if config.Sensitive {
 			continue
 		}
+		// The broker already sent the fallback chain — kadm asks for synonyms on
+		// every describe — so naming it costs no extra round trip. The first
+		// synonym normally repeats the effective value under its own source; it
+		// is kept, because "topic override 250 GB, broker default 1 GB" is the
+		// comparison worth seeing.
+		fallbacks := make([]topicConfigFallback, 0, len(config.Synonyms))
+		for _, synonym := range config.Synonyms {
+			value := ""
+			if synonym.Value != nil {
+				value = *synonym.Value
+			}
+			fallbacks = append(fallbacks, topicConfigFallback{
+				Key:    synonym.Key,
+				Value:  value,
+				Source: configSourceName(synonym.Source),
+			})
+		}
+
 		configs = append(configs, topicConfig{
 			Key:        config.Key,
 			Value:      config.MaybeValue(),
 			Source:     configSourceName(config.Source),
 			SetOnTopic: config.Source == kmsg.ConfigSourceDynamicTopicConfig,
+			Fallbacks:  fallbacks,
 		})
 	}
 	sort.Slice(configs, func(i, j int) bool { return configs[i].Key < configs[j].Key })

--- a/internal/connector/postgres/stats.go
+++ b/internal/connector/postgres/stats.go
@@ -187,6 +187,28 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 			LIMIT 200`,
 	},
 
+	// An index nothing reads still costs a write on every insert and update, and
+	// still occupies its disk. Ordered by size, because that is what dropping it
+	// gives back.
+	connector.StatsIndexes: {
+		hint: "Scan counts are since the last statistics reset — a fresh zero means unknown, not unused.",
+		sql: `
+			SELECT s.schemaname || '.' || s.relname                  AS "table",
+			       s.indexrelname                                    AS index,
+			       pg_size_pretty(pg_relation_size(s.indexrelid))    AS size,
+			       s.idx_scan                                        AS scans,
+			       date_trunc('second', st.stats_reset)              AS stats_since,
+			       i.indisunique                                     AS is_unique
+			FROM pg_stat_user_indexes s
+			JOIN pg_index i ON i.indexrelid = s.indexrelid
+			LEFT JOIN pg_stat_database st ON st.datname = current_database()
+			WHERE s.idx_scan = 0
+			  AND NOT i.indisprimary
+			  AND NOT i.indisunique
+			ORDER BY pg_relation_size(s.indexrelid) DESC
+			LIMIT 200`,
+	},
+
 	// Replication lag in bytes and in time. Bytes answer "how far behind", the
 	// time columns answer "how long behind" — a replica can be a few megabytes
 	// behind for a second or for an hour, and only the second one is an outage.

--- a/internal/connector/postgres/stats.go
+++ b/internal/connector/postgres/stats.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -42,7 +43,35 @@ func (p *PostgresConnector) ServerStats(ctx context.Context, section connector.S
 		return nil, explainStatsError(section, err)
 	}
 	result.Meta = map[string]any{"section": string(section), "hint": query.hint}
+	if notice := redactionNotice(section, result); notice != "" {
+		result.Meta["notice"] = notice
+	}
 	return result, nil
+}
+
+// Postgres redacts rather than refuses: a role without pg_read_all_stats still
+// gets every row of pg_stat_statements, with the query text replaced by
+// "<insufficient privilege>". Nothing errors, so without this the section is a
+// wall of identical placeholders and no explanation of why.
+func redactionNotice(section connector.ServerStatsSection, result *connector.DataResult) string {
+	if section != connector.StatsStatements || len(result.Rows) == 0 {
+		return ""
+	}
+
+	redacted := 0
+	for _, row := range result.Rows {
+		if text, ok := row["query"].(string); ok && strings.Contains(text, "insufficient privilege") {
+			redacted++
+		}
+	}
+	if redacted == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"%d of %d query texts are hidden: this role may only read its own. Granting pg_monitor "+
+			"(or pg_read_all_stats) reveals the rest; the timings above are accurate either way.",
+		redacted, len(result.Rows))
 }
 
 type statsQuery struct {
@@ -124,6 +153,7 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 	connector.StatsActivity: {
 		hint: "Sessions on this server. A limited role sees only its own.",
 		sql: `
+			/* kizuna:stats */
 			SELECT a.pid,
 			       a.state,
 			       a.usename                                   AS "user",
@@ -151,6 +181,7 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 	connector.StatsStatements: {
 		hint: "Since the last pg_stat_statements reset, not since server start.",
 		sql: `
+			/* kizuna:stats */
 			SELECT round(s.total_exec_time)::bigint            AS total_ms,
 			       s.calls,
 			       round(s.mean_exec_time::numeric, 2)         AS mean_ms,
@@ -160,8 +191,12 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 			             / NULLIF(sum(s.total_exec_time) OVER (), 0))::int AS pct_time,
 			       left(regexp_replace(s.query, '\s+', ' ', 'g'), 300)     AS query
 			FROM pg_stat_statements s
+			-- Excludes the queries this screen runs. Without it Kizuna measures
+			-- itself, tops its own ranking, and climbs with every Refresh. The
+			-- marker is a literal in our own SQL, never user input.
+			WHERE s.query NOT LIKE '%kizuna:stats%'
 			ORDER BY s.total_exec_time DESC
-			LIMIT 200`,
+			LIMIT 50`,
 	},
 
 	// Size and neglect side by side. A table is rarely interesting for its size
@@ -170,14 +205,18 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 	connector.StatsTables: {
 		hint: "Dead-tuple counts are estimates maintained by the statistics collector.",
 		sql: `
+			/* kizuna:stats */
 			SELECT s.schemaname || '.' || s.relname                       AS "table",
 			       pg_size_pretty(pg_total_relation_size(c.oid))          AS total,
 			       pg_size_pretty(pg_table_size(c.oid))                   AS data,
 			       pg_size_pretty(pg_indexes_size(c.oid))                 AS indexes,
 			       s.n_live_tup                                           AS live_rows,
 			       s.n_dead_tup                                           AS dead_rows,
-			       CASE WHEN s.n_live_tup > 0
-			            THEN round(100.0 * s.n_dead_tup / s.n_live_tup)::int
+			       -- Share of the table's row versions that are dead, not the
+			       -- dead-to-live ratio: a table with 4 live and 11 dead rows is
+			       -- 73% dead, and reporting 275% reads as a broken number.
+			       CASE WHEN s.n_live_tup + s.n_dead_tup > 0
+			            THEN round(100.0 * s.n_dead_tup / (s.n_live_tup + s.n_dead_tup))::int
 			       END                                                    AS dead_pct,
 			       date_trunc('second', GREATEST(s.last_autovacuum, s.last_vacuum)) AS last_vacuum,
 			       date_trunc('second', GREATEST(s.last_autoanalyze, s.last_analyze)) AS last_analyze
@@ -193,6 +232,7 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 	connector.StatsIndexes: {
 		hint: "Scan counts are since the last statistics reset — a fresh zero means unknown, not unused.",
 		sql: `
+			/* kizuna:stats */
 			SELECT s.schemaname || '.' || s.relname                  AS "table",
 			       s.indexrelname                                    AS index,
 			       pg_size_pretty(pg_relation_size(s.indexrelid))    AS size,
@@ -216,6 +256,7 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 	connector.StatsSequences: {
 		hint: "Headroom is measured against the column's type, not the sequence's own max_value.",
 		sql: `
+			/* kizuna:stats */
 			WITH owned AS (
 			    SELECT c.oid                        AS seq_oid,
 			           n.nspname || '.' || c.relname AS sequence,
@@ -253,6 +294,7 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 	connector.StatsReplication: {
 		hint: "Rows appear on a primary with connected replicas; a replica reports none.",
 		sql: `
+			/* kizuna:stats */
 			SELECT r.application_name                       AS replica,
 			       r.client_addr::text                      AS client,
 			       r.state,

--- a/internal/connector/postgres/stats.go
+++ b/internal/connector/postgres/stats.go
@@ -209,6 +209,44 @@ var statsQueries = map[connector.ServerStatsSection]statsQuery{
 			LIMIT 200`,
 	},
 
+	// A sequence feeding an integer column stops at 2147483647, and the inserts
+	// simply start failing. The ceiling comes from the COLUMN, not the sequence:
+	// pg_sequences reports max_value as 2^63 for almost everything, so reading it
+	// alone reports 0% used on a sequence with a week to live.
+	connector.StatsSequences: {
+		hint: "Headroom is measured against the column's type, not the sequence's own max_value.",
+		sql: `
+			WITH owned AS (
+			    SELECT c.oid                        AS seq_oid,
+			           n.nspname || '.' || c.relname AS sequence,
+			           dc.relname                    AS "table",
+			           a.attname                     AS column,
+			           format_type(a.atttypid, NULL) AS column_type,
+			           CASE a.atttypid
+			               WHEN 'smallint'::regtype THEN 32767::bigint
+			               WHEN 'integer'::regtype  THEN 2147483647::bigint
+			               ELSE 9223372036854775807::bigint
+			           END                           AS ceiling
+			    FROM pg_class c
+			    JOIN pg_namespace n ON n.oid = c.relnamespace
+			    JOIN pg_depend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass
+			    JOIN pg_class dc ON dc.oid = d.refobjid
+			    JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+			    WHERE c.relkind = 'S' AND d.deptype IN ('a', 'i')
+			)
+			SELECT o.sequence,
+			       o."table" || '.' || o.column AS feeds,
+			       o.column_type,
+			       s.last_value,
+			       o.ceiling                    AS max_value,
+			       round(100.0 * COALESCE(s.last_value, 0) / o.ceiling, 2) AS pct_used
+			FROM owned o
+			JOIN pg_sequences s
+			  ON s.schemaname || '.' || s.sequencename = o.sequence
+			ORDER BY 100.0 * COALESCE(s.last_value, 0) / o.ceiling DESC
+			LIMIT 200`,
+	},
+
 	// Replication lag in bytes and in time. Bytes answer "how far behind", the
 	// time columns answer "how long behind" — a replica can be a few megabytes
 	// behind for a second or for an hour, and only the second one is an outage.

--- a/internal/connector/postgres/stats_test.go
+++ b/internal/connector/postgres/stats_test.go
@@ -72,7 +72,7 @@ func TestEverySectionHasAQuery(t *testing.T) {
 	for _, section := range []connector.ServerStatsSection{
 		connector.StatsActivity, connector.StatsStatements,
 		connector.StatsTables, connector.StatsReplication,
-		connector.StatsIndexes,
+		connector.StatsIndexes, connector.StatsSequences,
 	} {
 		query, ok := statsQueries[section]
 		if !ok {

--- a/internal/connector/postgres/stats_test.go
+++ b/internal/connector/postgres/stats_test.go
@@ -72,6 +72,7 @@ func TestEverySectionHasAQuery(t *testing.T) {
 	for _, section := range []connector.ServerStatsSection{
 		connector.StatsActivity, connector.StatsStatements,
 		connector.StatsTables, connector.StatsReplication,
+		connector.StatsIndexes,
 	} {
 		query, ok := statsQueries[section]
 		if !ok {

--- a/internal/connector/redis/redis.go
+++ b/internal/connector/redis/redis.go
@@ -230,6 +230,7 @@ func (c *RedisConnector) GetInfo(ctx context.Context) (*connector.ConnInfo, erro
 		if stats.nodes > 1 {
 			extra["node_used_memory"] = stats.usedMemory / int64(stats.nodes)
 			extra["node_maxmemory"] = stats.maxMemory / int64(stats.nodes)
+			extra["nodes"] = stats.nodeStats
 		}
 		// Reported per node by Redis; over a cluster the honest aggregate is the
 		// ratio of the totals rather than one node's figure.
@@ -291,6 +292,20 @@ type clusterStats struct {
 	rss       int64
 	peak      int64
 	clients   int64
+	// nodeStats is what each master reported on its own. The totals above hide
+	// skew, and skew is the thing worth seeing: a cluster at 67% overall with one
+	// node at 95% starts refusing writes for that node's slots while the summary
+	// still looks calm.
+	nodeStats []redisNodeStat
+}
+
+type redisNodeStat struct {
+	Address    string `json:"address"`
+	Keys       int64  `json:"keys"`
+	UsedMemory int64  `json:"used_memory"`
+	MaxMemory  int64  `json:"maxmemory"`
+	Clients    int64  `json:"connected_clients"`
+	Uptime     string `json:"uptime_in_seconds,omitempty"`
 }
 
 func statsFromInfo(parsed map[string]string) clusterStats {
@@ -361,7 +376,16 @@ func (c *RedisConnector) collectStats(ctx context.Context, parsed map[string]str
 			return clusterStats{}, err
 		}
 
-		node := statsFromInfo(parseRedisInfo(raw))
+		parsedNode := parseRedisInfo(raw)
+		node := statsFromInfo(parsedNode)
+		total.nodeStats = append(total.nodeStats, redisNodeStat{
+			Address:    master,
+			Keys:       size,
+			UsedMemory: node.usedMemory,
+			MaxMemory:  node.maxMemory,
+			Clients:    node.clients,
+			Uptime:     parsedNode["uptime_in_seconds"],
+		})
 		total.nodes++
 		total.keys += size
 		total.usedMemory += node.usedMemory


### PR DESCRIPTION
The four remaining items from the plan, one commit each.

### Kafka — what a setting falls back to

The Config tab said a value was set on the topic, but not what the cluster would apply without it, or which broker setting to change for every topic at once. Both were already in the response: kadm asks for synonyms on every describe and we discarded them, so this costs no extra round trip.

`retention.bytes = 250000000000 (topic)` now shows `log.retention.bytes = -1 (default)` beside it — the comparison that tells you whether an override is doing anything.

### Redis — the masters behind the total

Cluster totals hide skew, and skew is what matters: a cluster at 67% overall with one node at 95% is already refusing writes for that node's slots while the summary looks calm. Each master is listed with its keys, memory, limit and share, the over-75% ones coloured. `collectStats` already walked the masters and threw the per-node figures away.

### Postgres — unused indexes

Indexes nothing has read, largest first, with the size dropping one gives back. Primary and unique indexes are excluded — they are constraints, not optimisations, and their scan count says nothing about whether they may go.

Scan counts are since the last statistics reset, so the section says so: a fresh zero means unknown, not unused.

### Postgres — sequences near their ceiling

A sequence feeding an `integer` column stops at 2 147 483 647 and inserts simply begin to fail. Nothing warns about it.

The ceiling comes from the **column**, not the sequence: `pg_sequences.max_value` reports 2^63 for almost everything, so reading it alone shows 0% used on a sequence with a week to live. The sequence is joined to the column it feeds through `pg_depend` and measured against that type's limit.

### Verification

On local containers: a sequence set to 2 000 000 000 on an `integer` column reports 93.13% (reading `max_value` instead would have said 0.00%), an index with zero scans is listed, three Redis masters appear individually, and a topic's `retention.bytes` override shows its broker fallback. Go tests cover that every declared section has a query and a hint.
