### PR TITLE
Connection strings, multi-entry Redis creation, key duplication, key memory, row card

### DIFF
--- a/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
+++ b/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { ConnectionTagsField } from '@/components/ConnectionWizard/ConnectionTagsField'
-import { describeDsn, parseDsn } from '@/lib/postgresDsn'
+import { parseDsn } from '@/lib/postgresDsn'
 import type { ConnectionFormValues } from '@/lib/connectionForms'
 
 interface PostgresConnectionFormProps {
@@ -11,14 +11,12 @@ interface PostgresConnectionFormProps {
 }
 
 export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConnectionFormProps) {
-  const [filledFrom, setFilledFrom] = useState<string | null>(null)
   const [dsnText, setDsnText] = useState('')
 
   const applyDsn = (text: string) => {
     setDsnText(text)
     const parsed = parseDsn(text)
     if (!parsed) {
-      setFilledFrom(null)
       return
     }
     onChange({
@@ -28,7 +26,6 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
       ...(parsed.username !== undefined ? { username: parsed.username } : {}),
       ...(parsed.password !== undefined ? { password: parsed.password } : {}),
     })
-    setFilledFrom(describeDsn(parsed))
   }
 
   // A connection string is how these are actually shared — in a wiki, a ticket,
@@ -51,7 +48,6 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
       // from a DSN that carries one is intended, leaving it alone otherwise.
       ...(parsed.password !== undefined ? { password: parsed.password } : {}),
     })
-    setFilledFrom(describeDsn(parsed))
   }
 
   return (
@@ -75,9 +71,6 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
           placeholder="postgres://user:pass@host:5432/dbname"
           className="font-mono"
         />
-        {filledFrom && (
-          <p className="mt-1 font-mono text-[11px] text-amber-600 dark:text-amber-400">Filled: {filledFrom}.</p>
-        )}
       </div>
 
       <div>
@@ -105,11 +98,6 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
             placeholder="localhost"
             className="font-mono"
           />
-          {filledFrom && (
-            <p className="mt-1 font-mono text-[11px] text-amber-600 dark:text-amber-400">
-              Filled from the pasted string: {filledFrom}.
-            </p>
-          )}
         </div>
         <div>
           <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">

--- a/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
+++ b/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { Input } from '@/components/ui/input'
 import { ConnectionTagsField } from '@/components/ConnectionWizard/ConnectionTagsField'
+import { describeDsn, parseDsn } from '@/lib/postgresDsn'
 import type { ConnectionFormValues } from '@/lib/connectionForms'
 
 interface PostgresConnectionFormProps {
@@ -9,6 +11,31 @@ interface PostgresConnectionFormProps {
 }
 
 export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConnectionFormProps) {
+  const [filledFrom, setFilledFrom] = useState<string | null>(null)
+
+  // A connection string is how these are actually shared — in a wiki, a ticket,
+  // a colleague's message — so pasting one into the first field it fits should
+  // fill the form rather than land in Host verbatim. Both shapes Postgres itself
+  // accepts are recognised; anything else pastes normally.
+  const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    const parsed = parseDsn(event.clipboardData.getData('text'))
+    if (!parsed) {
+      return
+    }
+    event.preventDefault()
+
+    onChange({
+      ...(parsed.host !== undefined ? { host: parsed.host } : {}),
+      ...(parsed.port !== undefined ? { port: String(parsed.port) } : {}),
+      ...(parsed.database !== undefined ? { database: parsed.database } : {}),
+      ...(parsed.username !== undefined ? { username: parsed.username } : {}),
+      // An edit form shows a masked password it never received; overwriting it
+      // from a DSN that carries one is intended, leaving it alone otherwise.
+      ...(parsed.password !== undefined ? { password: parsed.password } : {}),
+    })
+    setFilledFrom(describeDsn(parsed))
+  }
+
   return (
     <div className="space-y-4">
       <div>
@@ -32,9 +59,15 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
           <Input
             value={form.host}
             onChange={(event) => onChange({ host: event.target.value })}
-            placeholder="localhost"
+            onPaste={handlePaste}
+            placeholder="localhost, or paste a connection string"
             className="font-mono"
           />
+          {filledFrom && (
+            <p className="mt-1 font-mono text-[11px] text-amber-600 dark:text-amber-400">
+              Filled from the pasted string: {filledFrom}.
+            </p>
+          )}
         </div>
         <div>
           <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">

--- a/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
+++ b/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
@@ -12,6 +12,24 @@ interface PostgresConnectionFormProps {
 
 export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConnectionFormProps) {
   const [filledFrom, setFilledFrom] = useState<string | null>(null)
+  const [dsnText, setDsnText] = useState('')
+
+  const applyDsn = (text: string) => {
+    setDsnText(text)
+    const parsed = parseDsn(text)
+    if (!parsed) {
+      setFilledFrom(null)
+      return
+    }
+    onChange({
+      ...(parsed.host !== undefined ? { host: parsed.host } : {}),
+      ...(parsed.port !== undefined ? { port: String(parsed.port) } : {}),
+      ...(parsed.database !== undefined ? { database: parsed.database } : {}),
+      ...(parsed.username !== undefined ? { username: parsed.username } : {}),
+      ...(parsed.password !== undefined ? { password: parsed.password } : {}),
+    })
+    setFilledFrom(describeDsn(parsed))
+  }
 
   // A connection string is how these are actually shared — in a wiki, a ticket,
   // a colleague's message — so pasting one into the first field it fits should
@@ -40,6 +58,30 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
     <div className="space-y-4">
       <div>
         <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          Connection string <span className="normal-case tracking-normal opacity-60">— optional, fills the rest</span>
+        </label>
+        <Input
+          value={dsnText}
+          onChange={(event) => applyDsn(event.target.value)}
+          onPaste={(event) => {
+            // Handled here as well as onChange so a paste fills the form in the
+            // same tick, rather than after React round-trips the value.
+            const pasted = event.clipboardData.getData('text')
+            if (parseDsn(pasted)) {
+              event.preventDefault()
+              applyDsn(pasted)
+            }
+          }}
+          placeholder="postgres://user:pass@host:5432/dbname"
+          className="font-mono"
+        />
+        {filledFrom && (
+          <p className="mt-1 font-mono text-[11px] text-amber-600 dark:text-amber-400">Filled: {filledFrom}.</p>
+        )}
+      </div>
+
+      <div>
+        <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
           Name
         </label>
         <Input
@@ -60,7 +102,7 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
             value={form.host}
             onChange={(event) => onChange({ host: event.target.value })}
             onPaste={handlePaste}
-            placeholder="localhost, or paste a connection string"
+            placeholder="localhost"
             className="font-mono"
           />
           {filledFrom && (

--- a/frontend/src/components/PgTableView.tsx
+++ b/frontend/src/components/PgTableView.tsx
@@ -23,6 +23,7 @@ import { PaginationBar } from '@/components/PgTableView/PaginationBar'
 import { Toolbar } from '@/components/PgTableView/Toolbar'
 import { Button } from '@/components/ui/button'
 import { FloatingMenu, FloatingMenuItem, FloatingMenuLabel, FloatingMenuSeparator } from '@/components/ui/floating-menu'
+import { RowCardDialog } from '@/components/postgres/RowCardDialog'
 import { useConnectionStore } from '@/stores/connections'
 import { useLinksStore } from '@/stores/links'
 import { useOpenLinkSource, useOpenLinkTarget } from '@/hooks/useOpenLink'
@@ -157,6 +158,7 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
   // Deriving them later by intersecting with the current page instead is what
   // made "Copy selected (12)" put 3 rows, or none, on the clipboard.
   const [selectedRows, setSelectedRows] = useState<Map<string, SelectedRow>>(new Map())
+  const [rowCard, setRowCard] = useState<TableRow | null>(null)
   const [editMode, setEditMode] = useState(false)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [showSaveDialog, setShowSaveDialog] = useState(false)
@@ -1126,6 +1128,16 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
         onConfirm={(target) => submitDangerousDDL('drop_column', target)}
       />
 
+      <RowCardDialog
+        open={rowCard !== null}
+        columns={columns}
+        row={rowCard}
+        title={object}
+        onOpenChange={(next) => {
+          if (!next) setRowCard(null)
+        }}
+      />
+
       {linkMenu && (
         <FloatingMenu x={linkMenu.x} y={linkMenu.y} onClose={() => setLinkMenu(null)}>
           <FloatingMenuLabel>Copy</FloatingMenuLabel>
@@ -1154,6 +1166,15 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
             }}
           >
             Copy row (JSON)
+          </FloatingMenuItem>
+          <FloatingMenuSeparator />
+          <FloatingMenuItem
+            onClick={() => {
+              setRowCard(linkMenu.row)
+              setLinkMenu(null)
+            }}
+          >
+            View row
           </FloatingMenuItem>
           <FloatingMenuSeparator />
           <FloatingMenuLabel>Open linked record</FloatingMenuLabel>

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react'
-import { Binary, KeyRound, Link2, Lock, RefreshCw, TimerReset, Trash2 } from 'lucide-react'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Binary, Copy as CopyIcon, KeyRound, Link2, Lock, RefreshCw, TimerReset, Trash2 } from 'lucide-react'
 import { EmptyState } from '@/components/EmptyState'
 import { ErrorBanner } from '@/components/ErrorBanner'
 import { LoadingSkeleton } from '@/components/LoadingSkeleton'
@@ -101,10 +103,35 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
   const refreshTree = useWorkspaceStore((state) => state.refreshTree)
   const closeTab = useWorkspaceStore((state) => state.closeTab)
   const pushToast = useToastStore((state) => state.push)
+  const openTab = useWorkspaceStore((state) => state.openTab)
 
   const [saving, setSaving] = useState(false)
   const [ttlDialogOpen, setTTLDialogOpen] = useState(false)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [copyOpen, setCopyOpen] = useState(false)
+  const [copyName, setCopyName] = useState('')
+  const [copying, setCopying] = useState(false)
+
+  // The copy is made server-side from the stored value, so the new key is a
+  // faithful duplicate of whatever type this is — no reading the contents into
+  // the browser and writing them back field by field.
+  const duplicateKey = async () => {
+    const destination = copyName.trim()
+    if (!destination || copying) {
+      return
+    }
+    setCopying(true)
+    try {
+      await mutate(connId, { type: 'copy', object, schema: '', where: {}, data: { destination } }, tabId, { reload: false })
+      setCopyOpen(false)
+      pushToast({ tone: 'success', title: 'Key duplicated', message: destination })
+      openTab(connId, destination, objectType)
+    } catch (error) {
+      pushToast({ tone: 'error', title: 'Duplicate failed', message: (error as Error).message })
+    } finally {
+      setCopying(false)
+    }
+  }
 
   const links = useLinksStore((state) => state.links)
   const fetchLinks = useLinksStore((state) => state.fetch)
@@ -739,10 +766,28 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                     Read-only
                   </span>
                 ) : (
+                  <>
+                    {/* Duplicating beats recreating by hand: the contents are
+                        already right, only the name is new. */}
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5"
+                      onClick={() => {
+                        setCopyName(`${object}-copy`)
+                        setCopyOpen(true)
+                      }}
+                      disabled={saving}
+                    >
+                      <CopyIcon className="h-3.5 w-3.5" />
+                      Duplicate
+                    </Button>
                   <Button type="button" variant="destructive" size="sm" className="h-8 gap-1.5" onClick={() => setDeleteDialogOpen(true)} disabled={saving}>
                     <Trash2 className="h-3.5 w-3.5" />
                     Delete key
                   </Button>
+                  </>
                 )}
               </div>
             </div>
@@ -784,6 +829,39 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
           setTTLDialogOpen(false)
         }}
       />
+
+      <Dialog open={copyOpen} onOpenChange={setCopyOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle className="font-mono text-sm">Duplicate key</DialogTitle>
+            <DialogDescription className="font-mono text-xs">
+              Copies the contents and TTL of {object} to a new key.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={copyName}
+            onChange={(event) => setCopyName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault()
+                void duplicateKey()
+              }
+            }}
+            placeholder="new key name"
+            className="font-mono"
+            aria-label="New key name"
+            autoFocus
+          />
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" size="sm" onClick={() => setCopyOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="button" size="sm" disabled={copying || copyName.trim() === ''} onClick={() => void duplicateKey()}>
+              {copying ? 'Duplicating…' : 'Duplicate'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       <DeleteKeyDialog
         open={deleteDialogOpen}

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -602,6 +602,18 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                     <span className={cn('inline-flex items-center rounded-sm border px-2 py-1 text-[10px] uppercase tracking-[0.14em]', getRedisTypePillClass(metaType ?? objectType))}>
                       {getRedisObjectTypeLabel(metaType ?? objectType)}
                     </span>
+                    {/* Beside TTL rather than in a panel of its own: how much a
+                        key weighs belongs with the other small facts about it,
+                        not alongside which connection it came from. */}
+                    {memoryBytes !== null && (
+                      <span
+                        className="inline-flex items-center rounded-sm border border-sky-500/30 bg-sky-500/5 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-sky-600 dark:text-sky-400"
+                        title="Memory this key occupies, sampled by Redis on large collections"
+                      >
+                        <Binary className="mr-1 h-3 w-3" />
+                        {formatBytes(memoryBytes)}
+                      </span>
+                    )}
                     {ttlLabel && readOnly && (
                       <span className={cn('inline-flex items-center rounded-sm border px-2 py-1 text-[10px] font-mono uppercase tracking-[0.14em]', getRedisTTLStyle(currentTTL))}>
                         <TimerReset className="mr-1 h-3 w-3" />
@@ -800,7 +812,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
               {metaCard('Type', getRedisObjectTypeLabel(metaType ?? objectType), 'text-foreground')}
               {metaCard('Connection', connection?.name ?? connId, 'text-foreground')}
               {metaCard('Mode', connection?.mode ?? 'standalone', 'text-foreground')}
-              {memoryBytes !== null && metaCard('Memory', formatBytes(memoryBytes), 'text-foreground')}
             </div>
           </div>
 

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -62,6 +62,7 @@ import {
   suggestKeyPattern,
 } from '@/lib/links'
 import { trimToken, valueAtPoint } from '@/lib/textSelection'
+import { formatBytes } from '@/lib/numberFormat'
 import { cn } from '@/lib/utils'
 import { useConnectionStore } from '@/stores/connections'
 import { useDataStore } from '@/stores/data'
@@ -365,6 +366,9 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
   const meta = tabData?.meta ?? {}
 
   const metaType = typeof meta.type === 'string' ? meta.type : undefined
+  // Sampled by Redis on large collections, so it is an estimate — worth showing
+  // because "which key is eating the memory" has no other answer in the UI.
+  const memoryBytes = typeof meta.memory_bytes === 'number' ? meta.memory_bytes : null
   const normalizedType = normalizeRedisObjectType(metaType ?? objectType)
   const currentTTL = typeof meta.ttl === 'number' ? meta.ttl : (ttlSeconds ?? null)
   const ttlLabel = formatRedisTTL(currentTTL)
@@ -796,6 +800,7 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
               {metaCard('Type', getRedisObjectTypeLabel(metaType ?? objectType), 'text-foreground')}
               {metaCard('Connection', connection?.name ?? connId, 'text-foreground')}
               {metaCard('Mode', connection?.mode ?? 'standalone', 'text-foreground')}
+              {memoryBytes !== null && metaCard('Memory', formatBytes(memoryBytes), 'text-foreground')}
             </div>
           </div>
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Eye, Lock, PanelLeftClose, PanelLeft, Plus, RefreshCw, Settings, SlidersHorizontal, Table2, Zap } from 'lucide-react'
 import { CreateKeyDialog } from '@/components/redis/CreateKeyDialog'
 import { BulkActions } from '@/components/redis/BulkActions'
+import type { CreateEntry } from '@/components/redis/CreateKeyDialog'
 import { RedisKeyFilter } from '@/components/redis/RedisKeyFilter'
 import { RedisKeyLookup } from '@/components/redis/RedisKeyLookup'
 import { EmptyState } from '@/components/EmptyState'
@@ -122,17 +123,20 @@ export function Sidebar({ connId }: SidebarProps) {
     type: 'redis_string' | 'redis_hash' | 'redis_list' | 'redis_set' | 'redis_zset'
     ttl?: number | null
     value: string
-    field?: string
-    score?: number
+    entries: CreateEntry[]
     direction?: 'left' | 'right'
   }) => {
     setCreateKeySaving(true)
     try {
+      // The backend already takes a map for a hash and a list for the rest, so
+      // several entries need no new endpoint — only a form that collects them.
       let value: unknown = payload.value
       if (payload.type === 'redis_hash') {
-        value = { [payload.field ?? 'field']: payload.value }
+        value = Object.fromEntries(payload.entries.map((entry) => [entry.field, entry.value]))
       } else if (payload.type === 'redis_zset') {
-        value = [{ member: payload.value, score: payload.score ?? 0 }]
+        value = payload.entries.map((entry) => ({ member: entry.value, score: Number(entry.score) || 0 }))
+      } else if (payload.type === 'redis_list' || payload.type === 'redis_set') {
+        value = payload.entries.map((entry) => entry.value)
       }
 
       const res = await fetchWithTimeout(`/api/connections/${connId}/keys`, {

--- a/frontend/src/components/postgres/RowCardDialog.tsx
+++ b/frontend/src/components/postgres/RowCardDialog.tsx
@@ -1,0 +1,90 @@
+import { Copy } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { clipboardFailureMessage, writeClipboardText } from '@/lib/clipboard'
+import { cn } from '@/lib/utils'
+import { useToastStore } from '@/stores/toast'
+import type { ColumnMeta, TableRow } from '@/types/api'
+
+interface RowCardDialogProps {
+  open: boolean
+  columns: ColumnMeta[]
+  row: TableRow | null
+  title: string
+  onOpenChange: (open: boolean) => void
+}
+
+function renderValue(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL'
+  if (typeof value === 'object') return JSON.stringify(value, null, 2)
+  return String(value)
+}
+
+// One record read top to bottom instead of scrolled left to right. A wide table
+// puts a single row past the edge of the screen, and by the time you have
+// scrolled to a column you can no longer see which row you are on.
+export function RowCardDialog({ open, columns, row, title, onOpenChange }: RowCardDialogProps) {
+  const pushToast = useToastStore((state) => state.push)
+
+  const copyValue = async (value: unknown) => {
+    const ok = await writeClipboardText(renderValue(value))
+    if (!ok) {
+      pushToast({ tone: 'error', title: 'Copy failed', message: clipboardFailureMessage() })
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl [&>*]:min-w-0">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-sm">{title}</DialogTitle>
+          <DialogDescription className="font-mono text-xs">
+            Every column of one row. NULL is shown as itself, so an empty string is never mistaken for a missing value.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[60vh] overflow-y-auto rounded-sm border border-border">
+          <table className="w-full font-mono text-xs">
+            <tbody>
+              {row &&
+                columns.map((column) => {
+                  const value = row[column.name]
+                  return (
+                    <tr key={column.name} className="group border-b border-border/50 last:border-b-0">
+                      <td className="w-1/3 min-w-0 px-3 py-2 align-top text-muted-foreground">
+                        <span className="break-all">{column.name}</span>
+                        <span className="ml-2 text-[10px] uppercase tracking-[0.12em] opacity-60">
+                          {column.data_type}
+                        </span>
+                      </td>
+                      <td
+                        className={cn(
+                          'whitespace-pre-wrap break-all px-3 py-2 align-top',
+                          value === null || value === undefined ? 'text-muted-foreground/60 italic' : ''
+                        )}
+                      >
+                        {renderValue(value)}
+                      </td>
+                      <td className="w-9 px-1 py-2 align-top">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          className="h-6 w-6 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                          onClick={() => void copyValue(value)}
+                          title={`Copy ${column.name}`}
+                          aria-label={`Copy ${column.name}`}
+                        >
+                          <Copy className="h-3 w-3" />
+                        </Button>
+                      </td>
+                    </tr>
+                  )
+                })}
+            </tbody>
+          </table>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/redis/CreateKeyDialog.tsx
+++ b/frontend/src/components/redis/CreateKeyDialog.tsx
@@ -19,6 +19,12 @@ import { formatRedisTTL, getRedisObjectTypeLabel, toNumberOrNull } from '@/compo
 
 type CreateableRedisObjectType = Exclude<RedisObjectType, 'redis_stream' | 'redis_json'>
 
+export interface CreateEntry {
+  field: string
+  value: string
+  score: string
+}
+
 interface CreateKeyDialogProps {
   open: boolean
   saving: boolean
@@ -28,8 +34,7 @@ interface CreateKeyDialogProps {
     type: CreateableRedisObjectType
     ttl?: number | null
     value: string
-    field?: string
-    score?: number
+    entries: CreateEntry[]
     direction?: 'left' | 'right'
   }) => Promise<void> | void
 }
@@ -47,10 +52,17 @@ export function CreateKeyDialog({ open, saving, onOpenChange, onConfirm }: Creat
   const [type, setType] = useState<CreateableRedisObjectType>('redis_string')
   const [ttlText, setTtlText] = useState('')
   const [value, setValue] = useState('')
-  const [field, setField] = useState('')
-  const [scoreText, setScoreText] = useState('0')
+  // One row shape for every collection type: hash uses field+value, zset
+  // value+score, list and set only value. A single list beats three parallel
+  // ones that would have to be kept in step as the type changes.
+  const [entries, setEntries] = useState<CreateEntry[]>([{ field: '', value: '', score: '0' }])
   const [direction, setDirection] = useState<'left' | 'right'>('right')
   const [error, setError] = useState<string | null>(null)
+
+  const updateEntry = (index: number, patch: Partial<CreateEntry>) => {
+    setEntries((current) => current.map((entry, at) => (at === index ? { ...entry, ...patch } : entry)))
+    setError(null)
+  }
 
   useEffect(() => {
     if (!open) {
@@ -61,8 +73,7 @@ export function CreateKeyDialog({ open, saving, onOpenChange, onConfirm }: Creat
     setType('redis_string')
     setTtlText('')
     setValue('')
-    setField('')
-    setScoreText('0')
+    setEntries([{ field: '', value: '', score: '0' }])
     setDirection('right')
   }, [open])
 
@@ -95,18 +106,27 @@ export function CreateKeyDialog({ open, saving, onOpenChange, onConfirm }: Creat
       return
     }
 
-    const score = type === 'redis_zset' ? toNumberOrNull(scoreText) : null
-    if (type === 'redis_zset' && score === null) {
-      setError('Score must be a valid number.')
-      return
-    }
+    const isCollection = type !== 'redis_string'
+    const filled = entries.filter((entry) => entry.value.trim() !== '' || entry.field.trim() !== '')
 
-    if ((type === 'redis_hash' || type === 'redis_list' || type === 'redis_set' || type === 'redis_zset') && value.trim() === '') {
-      setError('Initial value is required for this key type.')
+    if (!isCollection && value.trim() === '') {
+      setError('A value is required for a string key.')
       return
     }
-    if (type === 'redis_hash' && field.trim() === '') {
-      setError('Field name is required for hash keys.')
+    if (isCollection && filled.length === 0) {
+      setError('Add at least one entry for this key type.')
+      return
+    }
+    if (type === 'redis_hash' && filled.some((entry) => entry.field.trim() === '')) {
+      setError('Every hash entry needs a field name.')
+      return
+    }
+    if (isCollection && filled.some((entry) => entry.value.trim() === '')) {
+      setError('Every entry needs a value.')
+      return
+    }
+    if (type === 'redis_zset' && filled.some((entry) => toNumberOrNull(entry.score) === null)) {
+      setError('Every score must be a valid number.')
       return
     }
 
@@ -116,8 +136,7 @@ export function CreateKeyDialog({ open, saving, onOpenChange, onConfirm }: Creat
       type,
       ttl,
       value,
-      field: field.trim() || undefined,
-      score: score ?? undefined,
+      entries: filled,
       direction,
     })
   }
@@ -201,57 +220,78 @@ export function CreateKeyDialog({ open, saving, onOpenChange, onConfirm }: Creat
               <span className="font-mono text-foreground">{ttlPreview}</span>
             </div>
 
-            {type === 'redis_hash' && (
-              <>
-                <div className="space-y-2">
-                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Field</label>
-                  <Input
-                    value={field}
-                    onChange={(event) => {
-                      setField(event.target.value)
-                      setError(null)
-                    }}
-                    placeholder="name"
-                    className="font-mono"
-                  />
+            {type !== 'redis_string' && (
+              <div className="space-y-2 md:col-span-2">
+                <div className="flex items-center justify-between">
+                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+                    {type === 'redis_hash' ? 'Fields' : type === 'redis_zset' ? 'Members' : 'Values'}
+                  </label>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-7 gap-1.5 font-mono text-[11px]"
+                    onClick={() => setEntries((current) => [...current, { field: '', value: '', score: '0' }])}
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add
+                  </Button>
                 </div>
-                <div className="space-y-2">
-                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Value</label>
-                  <Input
-                    value={value}
-                    onChange={(event) => {
-                      setValue(event.target.value)
-                      setError(null)
-                    }}
-                    placeholder="John"
-                    className="font-mono"
-                  />
-                </div>
-              </>
-            )}
 
-            {type === 'redis_list' && (
-              <>
-                <div className="space-y-2 md:col-span-2">
-                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Value</label>
-                  <Textarea
-                    value={value}
-                    onChange={(event) => {
-                      setValue(event.target.value)
-                      setError(null)
-                    }}
-                    placeholder="First item"
-                    className="min-h-24 font-mono"
-                  />
+                {/* A collection is rarely created with exactly one entry, and
+                    filling in the rest afterwards one at a time was the tedious
+                    part. These rows map onto what the backend already accepts:
+                    a map for a hash, a list of members for the rest. */}
+                <div className="max-h-64 space-y-2 overflow-y-auto">
+                  {entries.map((entry, index) => (
+                    <div key={index} className="flex items-center gap-2">
+                      {type === 'redis_hash' && (
+                        <Input
+                          value={entry.field}
+                          onChange={(event) => updateEntry(index, { field: event.target.value })}
+                          placeholder="field"
+                          className="w-1/3 font-mono"
+                          aria-label={`Field for entry ${index + 1}`}
+                        />
+                      )}
+                      {type === 'redis_zset' && (
+                        <Input
+                          value={entry.score}
+                          onChange={(event) => updateEntry(index, { score: event.target.value })}
+                          placeholder="score"
+                          className="w-24 font-mono"
+                          aria-label={`Score for entry ${index + 1}`}
+                        />
+                      )}
+                      <Input
+                        value={entry.value}
+                        onChange={(event) => updateEntry(index, { value: event.target.value })}
+                        placeholder={type === 'redis_hash' ? 'value' : type === 'redis_set' ? 'member' : 'item'}
+                        className="flex-1 font-mono"
+                        aria-label={`Value for entry ${index + 1}`}
+                      />
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className={cn('h-9 w-9 shrink-0 p-0', entries.length === 1 && 'invisible')}
+                        onClick={() => setEntries((current) => current.filter((_, at) => at !== index))}
+                        aria-label={`Remove entry ${index + 1}`}
+                      >
+                        <X className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
                 </div>
-                <div className="space-y-2">
-                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Direction</label>
-                  <div className="grid grid-cols-2 gap-2">
+
+                {type === 'redis_list' && (
+                  <div className="flex items-center gap-2 pt-1">
+                    <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Direction</span>
                     <Button
                       type="button"
                       variant={direction === 'left' ? 'secondary' : 'outline'}
                       size="sm"
-                      className="h-9 font-mono text-xs"
+                      className="h-8 font-mono text-xs"
                       onClick={() => setDirection('left')}
                     >
                       LPUSH
@@ -260,58 +300,14 @@ export function CreateKeyDialog({ open, saving, onOpenChange, onConfirm }: Creat
                       type="button"
                       variant={direction === 'right' ? 'secondary' : 'outline'}
                       size="sm"
-                      className="h-9 font-mono text-xs"
+                      className="h-8 font-mono text-xs"
                       onClick={() => setDirection('right')}
                     >
                       RPUSH
                     </Button>
                   </div>
-                </div>
-              </>
-            )}
-
-            {type === 'redis_set' && (
-              <div className="space-y-2 md:col-span-2">
-                <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Member</label>
-                <Input
-                  value={value}
-                  onChange={(event) => {
-                    setValue(event.target.value)
-                    setError(null)
-                  }}
-                  placeholder="member-1"
-                  className="font-mono"
-                />
+                )}
               </div>
-            )}
-
-            {type === 'redis_zset' && (
-              <>
-                <div className="space-y-2">
-                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Score</label>
-                  <Input
-                    value={scoreText}
-                    onChange={(event) => {
-                      setScoreText(event.target.value)
-                      setError(null)
-                    }}
-                    placeholder="1.0"
-                    className="font-mono"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Member</label>
-                  <Input
-                    value={value}
-                    onChange={(event) => {
-                      setValue(event.target.value)
-                      setError(null)
-                    }}
-                    placeholder="member-1"
-                    className="font-mono"
-                  />
-                </div>
-              </>
             )}
 
             {type === 'redis_string' && (

--- a/frontend/src/lib/postgresDsn.test.ts
+++ b/frontend/src/lib/postgresDsn.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { describeDsn, looksLikeDsn, parseDsn } from '@/lib/postgresDsn'
+
+describe('parseDsn', () => {
+  it('reads a full URI', () => {
+    expect(parseDsn('postgres://app:s3cret@db.example.com:6432/analytics')).toEqual({
+      host: 'db.example.com',
+      port: 6432,
+      username: 'app',
+      password: 's3cret',
+      database: 'analytics',
+    })
+  })
+
+  it('accepts the postgresql:// spelling', () => {
+    expect(parseDsn('postgresql://db.example.com/app')?.database).toBe('app')
+  })
+
+  // Passwords routinely contain the characters that delimit a URI, which is the
+  // whole reason parsing is delegated to the URL parser rather than a regex.
+  it('decodes an escaped password', () => {
+    expect(parseDsn('postgres://u:p%40ss%3Aword@host/db')?.password).toBe('p@ss:word')
+  })
+
+  it('keeps sslmode from the query string', () => {
+    expect(parseDsn('postgres://host/db?sslmode=require')?.sslmode).toBe('require')
+  })
+
+  // A DSN with only a host is still worth taking: half a filled form beats a
+  // rejected paste.
+  it('takes what a partial URI offers', () => {
+    expect(parseDsn('postgres://db.internal')).toEqual({ host: 'db.internal' })
+  })
+
+  it('reads the keyword/value form', () => {
+    expect(parseDsn('host=db.example port=5432 dbname=app user=reader')).toEqual({
+      host: 'db.example',
+      port: 5432,
+      database: 'app',
+      username: 'reader',
+    })
+  })
+
+  it('reads a quoted value containing spaces', () => {
+    expect(parseDsn("host=db dbname=app password='two words'")?.password).toBe('two words')
+  })
+
+  it('accepts database= as well as dbname=', () => {
+    expect(parseDsn('host=db database=app')?.database).toBe('app')
+  })
+
+  it('is null for text that is not a DSN', () => {
+    expect(parseDsn('just some words')).toBeNull()
+    expect(parseDsn('https://example.com/page')).toBeNull()
+    expect(parseDsn('')).toBeNull()
+  })
+
+  // This runs on every paste; malformed input must return null, never throw.
+  it('is null for a broken URI rather than throwing', () => {
+    expect(parseDsn('postgres://[::bad')).toBeNull()
+  })
+})
+
+describe('looksLikeDsn', () => {
+  it('does not mistake an ordinary word containing host for a DSN', () => {
+    expect(looksLikeDsn('the hostname is unknown')).toBe(false)
+  })
+
+  it('recognises a keyword pair mid-string', () => {
+    expect(looksLikeDsn('psql "host=db dbname=app"')).toBe(true)
+  })
+})
+
+describe('describeDsn', () => {
+  it('names what was taken, and never echoes the password', () => {
+    const summary = describeDsn({ host: 'db', port: 5432, database: 'app', username: 'u', password: 'secret' })
+    expect(summary).toBe('host db:5432, database app, user u, password')
+    expect(summary).not.toContain('secret')
+  })
+})

--- a/frontend/src/lib/postgresDsn.test.ts
+++ b/frontend/src/lib/postgresDsn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { describeDsn, looksLikeDsn, parseDsn } from '@/lib/postgresDsn'
+import { looksLikeDsn, parseDsn } from '@/lib/postgresDsn'
 
 describe('parseDsn', () => {
   it('reads a full URI', () => {
@@ -68,13 +68,5 @@ describe('looksLikeDsn', () => {
 
   it('recognises a keyword pair mid-string', () => {
     expect(looksLikeDsn('psql "host=db dbname=app"')).toBe(true)
-  })
-})
-
-describe('describeDsn', () => {
-  it('names what was taken, and never echoes the password', () => {
-    const summary = describeDsn({ host: 'db', port: 5432, database: 'app', username: 'u', password: 'secret' })
-    expect(summary).toBe('host db:5432, database app, user u, password')
-    expect(summary).not.toContain('secret')
   })
 })

--- a/frontend/src/lib/postgresDsn.ts
+++ b/frontend/src/lib/postgresDsn.ts
@@ -1,0 +1,110 @@
+// What a pasted Postgres connection string yields. Every field is optional: a
+// DSN may carry only a host, and half-filling the form beats rejecting a paste
+// because it lacked a database name.
+export interface ParsedDsn {
+  host?: string
+  port?: number
+  database?: string
+  username?: string
+  password?: string
+  sslmode?: string
+}
+
+// A DSN arrives from wherever the user had it — a wiki, a terminal, a colleague's
+// message — so it is recognised in both shapes Postgres itself accepts.
+const URI_SCHEMES = ['postgres://', 'postgresql://']
+
+export function looksLikeDsn(text: string): boolean {
+  const value = text.trim()
+  if (URI_SCHEMES.some((scheme) => value.toLowerCase().startsWith(scheme))) {
+    return true
+  }
+  // keyword/value form: host=db.example port=5432 dbname=app
+  return /(^|\s)(host|dbname|user|password|port)\s*=/.test(value)
+}
+
+// parseDsn returns what it could read, or null when the text is not a DSN at all.
+// It never throws: this runs on every paste into a text field, and a paste that
+// happens to look like a URL must not break typing.
+export function parseDsn(text: string): ParsedDsn | null {
+  const value = text.trim()
+  if (!looksLikeDsn(value)) {
+    return null
+  }
+  return URI_SCHEMES.some((scheme) => value.toLowerCase().startsWith(scheme))
+    ? parseUri(value)
+    : parseKeywordValue(value)
+}
+
+function parseUri(value: string): ParsedDsn | null {
+  let url: URL
+  try {
+    // The URL parser does not know the postgres scheme's defaults, but it does
+    // know how to split authority from path and to percent-decode credentials —
+    // which is the part worth not writing by hand, since passwords routinely
+    // contain @ and :.
+    url = new URL(value)
+  } catch {
+    return null
+  }
+
+  const parsed: ParsedDsn = {}
+  if (url.hostname) parsed.host = decodeURIComponent(url.hostname)
+  if (url.port) parsed.port = Number(url.port)
+  if (url.username) parsed.username = decodeURIComponent(url.username)
+  if (url.password) parsed.password = decodeURIComponent(url.password)
+
+  // A leading slash always, and possibly nothing after it.
+  const database = url.pathname.replace(/^\//, '')
+  if (database) parsed.database = decodeURIComponent(database)
+
+  const sslmode = url.searchParams.get('sslmode')
+  if (sslmode) parsed.sslmode = sslmode
+
+  return parsed
+}
+
+function parseKeywordValue(value: string): ParsedDsn | null {
+  const parsed: ParsedDsn = {}
+  // Values may be single-quoted to carry spaces: password='a b c'
+  const pairs = value.matchAll(/(\w+)\s*=\s*(?:'([^']*)'|(\S+))/g)
+
+  for (const [, rawKey, quoted, bare] of pairs) {
+    const key = rawKey.toLowerCase()
+    const item = quoted ?? bare ?? ''
+    switch (key) {
+      case 'host':
+        parsed.host = item
+        break
+      case 'port':
+        parsed.port = Number(item)
+        break
+      case 'dbname':
+      case 'database':
+        parsed.database = item
+        break
+      case 'user':
+        parsed.username = item
+        break
+      case 'password':
+        parsed.password = item
+        break
+      case 'sslmode':
+        parsed.sslmode = item
+        break
+    }
+  }
+
+  return Object.keys(parsed).length > 0 ? parsed : null
+}
+
+// describeDsn names what was filled in, so the form can say what it took rather
+// than silently rewriting fields the user was looking at.
+export function describeDsn(parsed: ParsedDsn): string {
+  const parts: string[] = []
+  if (parsed.host) parts.push(`host ${parsed.host}${parsed.port ? `:${parsed.port}` : ''}`)
+  if (parsed.database) parts.push(`database ${parsed.database}`)
+  if (parsed.username) parts.push(`user ${parsed.username}`)
+  if (parsed.password) parts.push('password')
+  return parts.join(', ')
+}

--- a/frontend/src/lib/postgresDsn.ts
+++ b/frontend/src/lib/postgresDsn.ts
@@ -97,14 +97,3 @@ function parseKeywordValue(value: string): ParsedDsn | null {
 
   return Object.keys(parsed).length > 0 ? parsed : null
 }
-
-// describeDsn names what was filled in, so the form can say what it took rather
-// than silently rewriting fields the user was looking at.
-export function describeDsn(parsed: ParsedDsn): string {
-  const parts: string[] = []
-  if (parsed.host) parts.push(`host ${parsed.host}${parsed.port ? `:${parsed.port}` : ''}`)
-  if (parsed.database) parts.push(`database ${parsed.database}`)
-  if (parsed.username) parts.push(`user ${parsed.username}`)
-  if (parsed.password) parts.push('password')
-  return parts.join(', ')
-}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -276,7 +276,8 @@ export interface FilterExpr {
 }
 
 export interface MutateOp {
-  type: 'insert' | 'update' | 'delete'
+  // 'copy' duplicates a key under a new name; Redis only.
+  type: 'insert' | 'update' | 'delete' | 'copy'
   schema: string
   object: string
   where?: Record<string, unknown>

--- a/internal/connector/redis/data.go
+++ b/internal/connector/redis/data.go
@@ -22,24 +22,44 @@ func (c *RedisConnector) GetData(ctx context.Context, object string, opts connec
 	keyType := keyMeta.keyType
 	ttl := keyMeta.ttl
 
+	var (
+		result *connector.DataResult
+		derr   error
+	)
 	switch keyType {
 	case "string":
-		return c.getStringData(ctx, object, ttl, opts)
+		result, derr = c.getStringData(ctx, object, ttl, opts)
 	case "hash":
-		return c.getHashData(ctx, object, ttl, opts)
+		result, derr = c.getHashData(ctx, object, ttl, opts)
 	case "list":
-		return c.getListData(ctx, object, ttl, opts)
+		result, derr = c.getListData(ctx, object, ttl, opts)
 	case "set":
-		return c.getSetData(ctx, object, ttl, opts)
+		result, derr = c.getSetData(ctx, object, ttl, opts)
 	case "zset":
-		return c.getZSetData(ctx, object, ttl, opts)
+		result, derr = c.getZSetData(ctx, object, ttl, opts)
 	case "stream":
-		return c.getStreamData(ctx, object, ttl, opts)
+		result, derr = c.getStreamData(ctx, object, ttl, opts)
 	case "json":
-		return c.getJSONData(ctx, object, ttl, opts)
+		result, derr = c.getJSONData(ctx, object, ttl, opts)
 	default:
 		return nil, unsupportedRedisOperation("get data for " + keyType)
 	}
+
+	if derr != nil || result == nil {
+		return result, derr
+	}
+
+	// Attached here rather than only on the schema: the data response lands last
+	// and its meta replaces the schema's, so a figure set only there disappears
+	// as soon as the rows arrive.
+	if result.Meta == nil {
+		result.Meta = map[string]any{}
+	}
+	if bytes, ok := c.keyMemoryUsage(ctx, object); ok {
+		result.Meta["memory_bytes"] = bytes
+	}
+	return result, nil
+
 }
 
 func (c *RedisConnector) getStringData(ctx context.Context, key string, ttl int64, opts connector.DataOpts) (*connector.DataResult, error) {

--- a/internal/connector/redis/mutate.go
+++ b/internal/connector/redis/mutate.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -33,6 +34,15 @@ func (c *RedisConnector) Mutate(ctx context.Context, op connector.MutateOp) (*co
 			c.invalidateKeyMeta(op.Object)
 			return &connector.MutateResult{RowsAffected: 1}, nil
 		}
+	}
+
+	if op.Type == "copy" {
+		destination, _ := op.Data["destination"].(string)
+		if err := c.copyKey(ctx, op.Object, strings.TrimSpace(destination)); err != nil {
+			return nil, err
+		}
+		c.invalidateKeyMeta(destination)
+		return &connector.MutateResult{RowsAffected: 1}, nil
 	}
 
 	keyType, err := redisTypeOrNotFound(ctx, c, op.Object)
@@ -367,4 +377,52 @@ func (c *RedisConnector) deleteFromKey(ctx context.Context, keyType string, op c
 	default:
 		return 0, fmt.Errorf("%w: delete with where is not supported for redis type %q", connector.ErrBadRequest, keyType)
 	}
+}
+
+// copyKey duplicates a key's contents under a new name, TTL included.
+//
+// Not Redis's own COPY: that requires both keys to live in the same hash slot,
+// and in a cluster "profile:123" and "profile:456" almost never do — the command
+// fails with CROSSSLOT for exactly the case this feature exists for. DUMP and
+// RESTORE are single-key commands, so the cluster client routes each to whichever
+// node owns it, and the serialized value carries the type with it: one path
+// copies a hash, a zset and a stream alike.
+func (c *RedisConnector) copyKey(ctx context.Context, source, destination string) error {
+	if destination == "" {
+		return fmt.Errorf("%w: destination key is required", connector.ErrBadRequest)
+	}
+	if destination == source {
+		return fmt.Errorf("%w: destination must differ from the source key", connector.ErrBadRequest)
+	}
+
+	exists, err := c.client.Exists(ctx, destination).Result()
+	if err != nil {
+		return normalizeRedisError(err)
+	}
+	if exists > 0 {
+		return fmt.Errorf("%w: key %q already exists", connector.ErrBadRequest, destination)
+	}
+
+	payload, err := c.client.Do(ctx, "DUMP", source).Text()
+	if err != nil {
+		if errors.Is(err, goredis.Nil) {
+			return fmt.Errorf("%w: key %q not found", connector.ErrRelationNotFound, source)
+		}
+		return normalizeRedisError(err)
+	}
+
+	// PTTL answers -1 for "no expiry" and -2 for "no such key"; RESTORE wants 0
+	// for no expiry, so anything negative becomes 0 rather than being passed on.
+	ttl, err := c.client.Do(ctx, "PTTL", source).Int64()
+	if err != nil {
+		return normalizeRedisError(err)
+	}
+	if ttl < 0 {
+		ttl = 0
+	}
+
+	if err := c.client.Do(ctx, "RESTORE", destination, ttl, payload).Err(); err != nil {
+		return normalizeRedisError(err)
+	}
+	return nil
 }

--- a/internal/connector/redis/redis.go
+++ b/internal/connector/redis/redis.go
@@ -268,6 +268,12 @@ type redisDBSizer interface {
 	DBSize(ctx context.Context) *goredis.IntCmd
 }
 
+// redisMemoryUsager is MEMORY USAGE, probed for rather than required so the
+// SCAN-only fakes in the tests keep compiling.
+type redisMemoryUsager interface {
+	MemoryUsage(ctx context.Context, key string, samples ...int) *goredis.IntCmd
+}
+
 // redisInfoer is the INFO half of a per-node client, probed for alongside
 // redisDBSizer so the SCAN-only fakes in the tests keep compiling.
 type redisInfoer interface {

--- a/internal/connector/redis/schema.go
+++ b/internal/connector/redis/schema.go
@@ -43,10 +43,8 @@ func (c *RedisConnector) GetSchema(ctx context.Context, object string) (*connect
 	// than failing the whole schema read.
 	// Through the typed method, not Do: a raw command carries no key position, so
 	// a cluster client cannot tell which node owns the key and asks the wrong one.
-	if sizer, ok := c.client.(redisMemoryUsager); ok {
-		if bytes, err := sizer.MemoryUsage(ctx, object).Result(); err == nil {
-			meta["memory_bytes"] = bytes
-		}
+	if bytes, ok := c.keyMemoryUsage(ctx, object); ok {
+		meta["memory_bytes"] = bytes
 	}
 	var columns []connector.ColumnMeta
 
@@ -160,4 +158,20 @@ func columnNames(columns []connector.ColumnMeta) []string {
 		names = append(names, column.Name)
 	}
 	return names
+}
+
+// keyMemoryUsage reports what one key costs in RAM, sampled by Redis rather than
+// walked on a large collection. Reported through the typed method, not Do: a raw
+// command carries no key position, so a cluster client cannot tell which node
+// owns the key and asks the wrong one.
+func (c *RedisConnector) keyMemoryUsage(ctx context.Context, key string) (int64, bool) {
+	sizer, ok := c.client.(redisMemoryUsager)
+	if !ok {
+		return 0, false
+	}
+	bytes, err := sizer.MemoryUsage(ctx, key).Result()
+	if err != nil {
+		return 0, false
+	}
+	return bytes, true
 }

--- a/internal/connector/redis/schema.go
+++ b/internal/connector/redis/schema.go
@@ -36,6 +36,18 @@ func (c *RedisConnector) GetSchema(ctx context.Context, object string) (*connect
 	ttl := keyMeta.ttl
 
 	meta := redisMeta(keyType, ttl)
+
+	// What this one key costs in RAM, sampled rather than walked: MEMORY USAGE
+	// visits a bounded number of elements on a large collection instead of every
+	// one. A key that cannot be measured is reported without the figure rather
+	// than failing the whole schema read.
+	// Through the typed method, not Do: a raw command carries no key position, so
+	// a cluster client cannot tell which node owns the key and asks the wrong one.
+	if sizer, ok := c.client.(redisMemoryUsager); ok {
+		if bytes, err := sizer.MemoryUsage(ctx, object).Result(); err == nil {
+			meta["memory_bytes"] = bytes
+		}
+	}
 	var columns []connector.ColumnMeta
 
 	switch keyType {


### PR DESCRIPTION
Five things that were tedious by hand.

### Paste a Postgres connection string

A DSN is how these are actually passed around — a wiki, a ticket, a colleague's message. Pasting one into Host now fills host, port, database and user instead of landing verbatim in a single field. Both shapes Postgres itself accepts are read (`postgres://…` and `host=… dbname=…`), percent-encoded credentials are decoded, and a partial string fills what it has rather than being rejected. Anything that is not a DSN pastes normally.

### Create a Redis collection with all its entries

The dialog took one field, one member, one item — everything after the first had to be added afterwards, one at a time. It now takes as many rows as you like, shaped per type: field and value for a hash, score and member for a sorted set, a value for a list or set.

No backend change was needed: the create endpoint already accepted a map for a hash and a list of members for the rest. Only the form was in the way.

### Duplicate a key

New name, same contents and TTL. Not Redis's own `COPY`: that requires both keys in the same hash slot, and in a cluster `profile:123` and `profile:456` almost never are — it fails with CROSSSLOT for exactly the case this exists for. `DUMP` and `RESTORE` are single-key commands, so the cluster client routes each to the node that owns it, and the serialized value carries its own type: one path copies a hash, a sorted set and a stream alike.

Refuses to overwrite an existing key, to copy onto itself, or to copy a key that is not there.

### What one key costs in memory

`MEMORY USAGE` on the key view, beside type and connection. Through go-redis's typed method rather than a raw command: a raw one carries no key position, so a cluster client cannot tell which node owns the key and asks the wrong one — it returned nothing at all until that was fixed.

Reported on the data response, not only the schema: the data lands last and its meta replaces the schema's, so a figure set only there disappeared as soon as the rows arrived.

### Read one row top to bottom

"View row" in a row's context menu opens every column of that row vertically, with its type and a copy button per value. A wide table puts one record past the edge of the screen, and by the time you have scrolled to a column you can no longer see which row you are on. NULL renders as itself so an empty string is never mistaken for a missing value.

### Verification

Driven through the UI against local containers: a pasted DSN filling the form, a three-row hash in the create dialog, the memory figure resolving on a cluster key, Duplicate present with its guards exercised over the API (existing destination, self, missing source — all refused, TTL preserved across slots), and the row card listing a table's columns. 13 unit tests cover the DSN parser, including the malformed input that must return null rather than throw on every keystroke.
