### PR TITLE
Connect to Postgres over TLS

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,6 +8,59 @@ services:
     ports:
       - "55432:5432"
 
+  # Certificates for postgres-tls, made once into a named volume so the CA a
+  # saved connection carries stays valid when the containers are recreated.
+  # postgres:16-alpine has no openssl binary, hence the separate one-shot image.
+  postgres-tls-certs:
+    image: alpine/openssl:latest
+    entrypoint: sh
+    volumes:
+      - postgres-tls-certs:/certs
+    command:
+      - -c
+      - |
+        set -e
+        if [ -f /certs/server.crt ]; then echo "certificates already present"; exit 0; fi
+        openssl req -x509 -newkey rsa:2048 -nodes -days 3650 \
+          -keyout /certs/ca.key -out /certs/ca.crt -subj "/CN=kizuna-test-ca"
+        openssl req -newkey rsa:2048 -nodes \
+          -keyout /certs/server.key -out /certs/server.csr -subj "/CN=postgres-tls"
+        # Every name the server can be reached by: the service name from the
+        # compose network, and localhost/127.0.0.1 from the host. verify-full
+        # checks the name it dialled against these.
+        printf 'subjectAltName=DNS:postgres-tls,DNS:localhost,DNS:host.docker.internal,IP:127.0.0.1\n' > /certs/san.cnf
+        openssl x509 -req -in /certs/server.csr -CA /certs/ca.crt -CAkey /certs/ca.key \
+          -CAcreateserial -out /certs/server.crt -days 3650 -extfile /certs/san.cnf
+        # The postgres user in the server image owns the key and nothing else may
+        # read it, or the server refuses to start.
+        chown 70:70 /certs/server.key
+        chmod 600 /certs/server.key
+        echo "certificates generated"
+
+  postgres-tls:
+    image: postgres:16-alpine
+    depends_on:
+      postgres-tls-certs:
+        condition: service_completed_successfully
+    environment:
+      POSTGRES_USER: dev
+      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: devdb
+    volumes:
+      - postgres-tls-certs:/certs:ro
+    command:
+      - postgres
+      - -c
+      - ssl=on
+      - -c
+      - ssl_cert_file=/certs/server.crt
+      - -c
+      - ssl_key_file=/certs/server.key
+      - -c
+      - ssl_ca_file=/certs/ca.crt
+    ports:
+      - "55433:5432"
+
   redis:
     image: redis:7-alpine
     ports:
@@ -39,3 +92,6 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     ports:
       - "59092:9094"
+
+volumes:
+  postgres-tls-certs:

--- a/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
+++ b/frontend/src/components/ConnectionWizard/PostgresConnectionForm.tsx
@@ -1,8 +1,11 @@
 import { useState } from 'react'
 import { Input } from '@/components/ui/input'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import { ConnectionTagsField } from '@/components/ConnectionWizard/ConnectionTagsField'
 import { parseDsn } from '@/lib/postgresDsn'
 import type { ConnectionFormValues } from '@/lib/connectionForms'
+import type { PostgresSSLMode } from '@/types/api'
 
 interface PostgresConnectionFormProps {
   form: ConnectionFormValues
@@ -10,8 +13,23 @@ interface PostgresConnectionFormProps {
   isEdit: boolean
 }
 
+const SSL_MODES: { value: PostgresSSLMode; label: string; hint: string }[] = [
+  { value: 'disable', label: 'disable', hint: 'No TLS. The password crosses the network in the clear.' },
+  { value: 'prefer', label: 'prefer', hint: 'TLS when the server offers it, plaintext when it does not. Not verified either way.' },
+  { value: 'require', label: 'require', hint: 'TLS always. Without a CA below nothing about the certificate is checked.' },
+  { value: 'verify-ca', label: 'verify-ca', hint: 'The certificate must be signed by a trusted CA. Its hostname is not checked.' },
+  { value: 'verify-full', label: 'verify-full', hint: 'Signed by a trusted CA and issued for this host. Use this against anything real.' },
+]
+
+// A DSN that names an sslmode is describing the server's requirement, so it is
+// worth honouring — a pasted "?sslmode=require" should not land in a form that
+// then connects in the clear.
+const parsedSslMode = (value: string | undefined): PostgresSSLMode | undefined =>
+  SSL_MODES.some((mode) => mode.value === value) ? (value as PostgresSSLMode) : undefined
+
 export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConnectionFormProps) {
   const [dsnText, setDsnText] = useState('')
+  const activeMode = SSL_MODES.find((mode) => mode.value === form.pgSslMode) ?? SSL_MODES[0]
 
   const applyDsn = (text: string) => {
     setDsnText(text)
@@ -19,12 +37,14 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
     if (!parsed) {
       return
     }
+    const sslMode = parsedSslMode(parsed.sslmode)
     onChange({
       ...(parsed.host !== undefined ? { host: parsed.host } : {}),
       ...(parsed.port !== undefined ? { port: String(parsed.port) } : {}),
       ...(parsed.database !== undefined ? { database: parsed.database } : {}),
       ...(parsed.username !== undefined ? { username: parsed.username } : {}),
       ...(parsed.password !== undefined ? { password: parsed.password } : {}),
+      ...(sslMode !== undefined ? { pgSslMode: sslMode } : {}),
     })
   }
 
@@ -39,6 +59,7 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
     }
     event.preventDefault()
 
+    const sslMode = parsedSslMode(parsed.sslmode)
     onChange({
       ...(parsed.host !== undefined ? { host: parsed.host } : {}),
       ...(parsed.port !== undefined ? { port: String(parsed.port) } : {}),
@@ -47,6 +68,7 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
       // An edit form shows a masked password it never received; overwriting it
       // from a DSN that carries one is intended, leaving it alone otherwise.
       ...(parsed.password !== undefined ? { password: parsed.password } : {}),
+      ...(sslMode !== undefined ? { pgSslMode: sslMode } : {}),
     })
   }
 
@@ -149,6 +171,121 @@ export function PostgresConnectionForm({ form, onChange, isEdit }: PostgresConne
             className="font-mono"
           />
         </div>
+      </div>
+
+      <div className="space-y-4 rounded-md border border-border/60 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <label className="block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+              TLS
+            </label>
+            <p className="mt-1 text-[11px] text-muted-foreground">{activeMode.hint}</p>
+          </div>
+          <div className="w-36 shrink-0">
+            <Select
+              value={form.pgSslMode}
+              onValueChange={(value) => onChange({ pgSslMode: value as PostgresSSLMode })}
+            >
+              <SelectTrigger className="font-mono text-xs">
+                <SelectValue placeholder="sslmode" />
+              </SelectTrigger>
+              <SelectContent>
+                {SSL_MODES.map((mode) => (
+                  <SelectItem key={mode.value} value={mode.value}>
+                    {mode.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {form.pgSslMode !== 'disable' && (
+          <>
+            <div>
+              <label
+                htmlFor="pg-ssl-root-cert"
+                className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                CA certificate (PEM)
+              </label>
+              <Textarea
+                id="pg-ssl-root-cert"
+                value={form.pgSslRootCert}
+                onChange={(event) => onChange({ pgSslRootCert: event.target.value })}
+                placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'}
+                className="min-h-24 resize-y font-mono text-xs"
+                spellCheck={false}
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Needed for a certificate the system does not already trust — a private CA, or a cloud
+                provider's own root. Leave blank to verify against the system trust store.
+              </p>
+            </div>
+
+            <div>
+              <label
+                htmlFor="pg-ssl-server-name"
+                className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                Server name <span className="normal-case tracking-normal opacity-60">— optional</span>
+              </label>
+              <Input
+                id="pg-ssl-server-name"
+                value={form.pgSslServerName}
+                onChange={(event) => onChange({ pgSslServerName: event.target.value })}
+                placeholder="db.internal.example"
+                className="font-mono"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                The name the certificate is checked against, when it differs from Host — connecting
+                through a tunnel, an IP address, or a proxy.
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label
+                  htmlFor="pg-ssl-client-cert"
+                  className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
+                >
+                  Client certificate
+                </label>
+                <Textarea
+                  id="pg-ssl-client-cert"
+                  value={form.pgSslClientCert}
+                  onChange={(event) => onChange({ pgSslClientCert: event.target.value })}
+                  placeholder={'-----BEGIN CERTIFICATE-----'}
+                  className="min-h-20 resize-y font-mono text-xs"
+                  spellCheck={false}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="pg-ssl-client-key"
+                  className="mb-1 block text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground"
+                >
+                  Client key
+                  {isEdit && form.pgSslClientCert && (
+                    <span className="ml-1 normal-case opacity-50">(blank = keep)</span>
+                  )}
+                </label>
+                <Textarea
+                  id="pg-ssl-client-key"
+                  value={form.pgSslClientKey}
+                  onChange={(event) => onChange({ pgSslClientKey: event.target.value })}
+                  placeholder={isEdit && form.pgSslClientCert ? '••••••••' : '-----BEGIN PRIVATE KEY-----'}
+                  className="min-h-20 resize-y font-mono text-xs"
+                  spellCheck={false}
+                />
+              </div>
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              Only for servers that authenticate clients by certificate. The key is encrypted with the
+              rest of the configuration and is never sent back to this form.
+            </p>
+          </>
+        )}
       </div>
 
       <div>

--- a/frontend/src/lib/connectionForms.ts
+++ b/frontend/src/lib/connectionForms.ts
@@ -4,7 +4,9 @@ import type {
   ConnectionType,
   KafkaConfig,
   KafkaConnectionInput,
+  PostgresConfig,
   PostgresConnectionInput,
+  PostgresSSLMode,
   RedisConfig,
   RedisConnectionInput,
   RedisMode,
@@ -28,6 +30,11 @@ export interface ConnectionFormValues {
   kafkaBrokersText: string
   kafkaSaslMechanism: string
   kafkaTlsCaPem: string
+  pgSslMode: PostgresSSLMode
+  pgSslRootCert: string
+  pgSslClientCert: string
+  pgSslClientKey: string
+  pgSslServerName: string
   readOnly: boolean
 }
 
@@ -49,6 +56,14 @@ const postgresDefaults: ConnectionFormValues = {
   kafkaBrokersText: '',
   kafkaSaslMechanism: '',
   kafkaTlsCaPem: '',
+  // libpq's own default, and what a new connection should try: TLS when the
+  // server offers it, plaintext when it does not. Connections stored before
+  // this setting existed stay on "disable", which the server fills in for them.
+  pgSslMode: 'prefer',
+  pgSslRootCert: '',
+  pgSslClientCert: '',
+  pgSslClientKey: '',
+  pgSslServerName: '',
   readOnly: false,
 }
 
@@ -152,6 +167,12 @@ export function createConnectionFormFromConnection(connection?: Connection): Con
     kafkaBrokersText: connection.kafka_config?.brokers?.join('\n') ?? '',
     kafkaSaslMechanism: connection.kafka_config?.sasl_mechanism ?? '',
     kafkaTlsCaPem: connection.kafka_config?.tls_ca_pem ?? '',
+    pgSslMode: connection.postgres_config?.ssl_mode ?? 'disable',
+    pgSslRootCert: connection.postgres_config?.ssl_root_cert ?? '',
+    pgSslClientCert: connection.postgres_config?.ssl_client_cert ?? '',
+    // Never sent back by the server; blank means the stored key is kept.
+    pgSslClientKey: '',
+    pgSslServerName: connection.postgres_config?.ssl_server_name ?? '',
     readOnly: connection.read_only ?? false,
   }
 
@@ -238,6 +259,20 @@ export function buildConnectionInput(form: ConnectionFormValues): ConnectionInpu
     return kafkaInput
   }
 
+  const postgresConfig: PostgresConfig = { ssl_mode: form.pgSslMode }
+  if (form.pgSslMode !== 'disable') {
+    // Only sent when TLS is on: a certificate left over from a mode the user
+    // turned off should not travel with the request, let alone be stored.
+    const rootCert = form.pgSslRootCert.trim()
+    const clientCert = form.pgSslClientCert.trim()
+    const clientKey = form.pgSslClientKey.trim()
+    const serverName = form.pgSslServerName.trim()
+    if (rootCert) postgresConfig.ssl_root_cert = rootCert
+    if (clientCert) postgresConfig.ssl_client_cert = clientCert
+    if (clientKey) postgresConfig.ssl_client_key = clientKey
+    if (serverName) postgresConfig.ssl_server_name = serverName
+  }
+
   const postgresInput: PostgresConnectionInput = {
     name: form.name.trim(),
     type: 'postgres',
@@ -248,6 +283,7 @@ export function buildConnectionInput(form: ConnectionFormValues): ConnectionInpu
     password: form.password,
     tags,
     read_only: form.readOnly,
+    postgres_config: postgresConfig,
   }
   return postgresInput
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -8,6 +8,18 @@ export interface KafkaConfig {
   tls_ca_pem?: string
   schema_registry_url?: string
 }
+export type PostgresSSLMode = 'disable' | 'prefer' | 'require' | 'verify-ca' | 'verify-full'
+
+export interface PostgresConfig {
+  ssl_mode?: PostgresSSLMode
+  ssl_root_cert?: string
+  ssl_client_cert?: string
+  // Write-only: the server never sends the key back, so an empty value on an
+  // edit means "keep the stored one".
+  ssl_client_key?: string
+  ssl_server_name?: string
+}
+
 export interface RedisConfig {
   mode?: RedisMode
   address?: string
@@ -49,6 +61,7 @@ export interface Connection {
   masterName?: string
   clusterAddresses?: string[]
   sentinelAddresses?: string[]
+  postgres_config?: PostgresConfig
   redis_config?: RedisConfig
   kafka_config?: KafkaConfig
   tags?: string[]
@@ -67,6 +80,7 @@ export interface PostgresConnectionInput {
   tags: string[]
   read_only?: boolean
   visible_schemas?: string[] | null
+  postgres_config?: PostgresConfig
 }
 
 export interface RedisConnectionInput {

--- a/internal/api/handlers/connections.go
+++ b/internal/api/handlers/connections.go
@@ -21,40 +21,42 @@ type ConnectionsHandler struct {
 }
 
 type connectionRequest struct {
-	ID             string              `json:"id"`
-	Name           string              `json:"name"`
-	Type           string              `json:"type"`
-	Host           string              `json:"host"`
-	Port           int                 `json:"port"`
-	Database       string              `json:"database"`
-	Username       string              `json:"username"`
-	Tags           []string            `json:"tags"`
-	Password       string              `json:"password"`
-	VisibleSchemas []string            `json:"visible_schemas"`
-	ReadOnly       bool                `json:"read_only"`
-	RedisConfig    *config.RedisConfig `json:"redis_config"`
-	KafkaConfig    *config.KafkaConfig `json:"kafka_config"`
+	ID             string                 `json:"id"`
+	Name           string                 `json:"name"`
+	Type           string                 `json:"type"`
+	Host           string                 `json:"host"`
+	Port           int                    `json:"port"`
+	Database       string                 `json:"database"`
+	Username       string                 `json:"username"`
+	Tags           []string               `json:"tags"`
+	Password       string                 `json:"password"`
+	VisibleSchemas []string               `json:"visible_schemas"`
+	ReadOnly       bool                   `json:"read_only"`
+	PostgresConfig *config.PostgresConfig `json:"postgres_config"`
+	RedisConfig    *config.RedisConfig    `json:"redis_config"`
+	KafkaConfig    *config.KafkaConfig    `json:"kafka_config"`
 }
 
 type connectionResponse struct {
-	ID               string              `json:"id"`
-	Name             string              `json:"name"`
-	Type             string              `json:"type"`
-	Host             string              `json:"host"`
-	Port             int                 `json:"port"`
-	Database         string              `json:"database"`
-	Username         string              `json:"username"`
-	Tags             []string            `json:"tags,omitempty"`
-	VisibleSchemas   []string            `json:"visible_schemas"`
-	ReadOnly         bool                `json:"read_only"`
-	RedisConfig      *config.RedisConfig `json:"redis_config,omitempty"`
-	KafkaConfig      *config.KafkaConfig `json:"kafka_config,omitempty"`
-	Mode             config.RedisMode    `json:"mode,omitempty"`
-	Separator        string              `json:"separator,omitempty"`
-	TLSEnabled       bool                `json:"tlsEnabled,omitempty"`
-	MasterName       string              `json:"masterName,omitempty"`
-	ClusterAddresses []string            `json:"clusterAddresses,omitempty"`
-	SentinelAddrs    []string            `json:"sentinelAddresses,omitempty"`
+	ID               string                 `json:"id"`
+	Name             string                 `json:"name"`
+	Type             string                 `json:"type"`
+	Host             string                 `json:"host"`
+	Port             int                    `json:"port"`
+	Database         string                 `json:"database"`
+	Username         string                 `json:"username"`
+	Tags             []string               `json:"tags,omitempty"`
+	VisibleSchemas   []string               `json:"visible_schemas"`
+	ReadOnly         bool                   `json:"read_only"`
+	PostgresConfig   *config.PostgresConfig `json:"postgres_config,omitempty"`
+	RedisConfig      *config.RedisConfig    `json:"redis_config,omitempty"`
+	KafkaConfig      *config.KafkaConfig    `json:"kafka_config,omitempty"`
+	Mode             config.RedisMode       `json:"mode,omitempty"`
+	Separator        string                 `json:"separator,omitempty"`
+	TLSEnabled       bool                   `json:"tlsEnabled,omitempty"`
+	MasterName       string                 `json:"masterName,omitempty"`
+	ClusterAddresses []string               `json:"clusterAddresses,omitempty"`
+	SentinelAddrs    []string               `json:"sentinelAddresses,omitempty"`
 }
 
 func NewConnectionsHandler(cfg *config.AppConfig, manager *connector.ConnectionManager) *ConnectionsHandler {
@@ -93,6 +95,12 @@ func (h *ConnectionsHandler) Create(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		encPassword = encrypted
+	}
+
+	if err := h.prepareClientKey(req.PostgresConfig, ""); err != nil {
+		slog.Error("failed to encrypt ssl client key", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to encrypt ssl client key")
+		return
 	}
 
 	// Generate UUID
@@ -141,6 +149,12 @@ func (h *ConnectionsHandler) TestConfig(w http.ResponseWriter, r *http.Request) 
 		password = encrypted
 	}
 
+	if err := h.prepareClientKey(req.PostgresConfig, h.storedClientKey(req.ID)); err != nil {
+		slog.Error("failed to encrypt ssl client key", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to encrypt ssl client key")
+		return
+	}
+
 	cfg := buildConnectionConfig(req, password)
 
 	start := time.Now()
@@ -168,17 +182,18 @@ func (h *ConnectionsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name        *string             `json:"name"`
-		Type        *string             `json:"type"`
-		Host        *string             `json:"host"`
-		Port        *int                `json:"port"`
-		Database    *string             `json:"database"`
-		Username    *string             `json:"username"`
-		Tags        *[]string           `json:"tags"`
-		Password    *string             `json:"password"`
-		ReadOnly    *bool               `json:"read_only"`
-		RedisConfig *config.RedisConfig `json:"redis_config"`
-		KafkaConfig *config.KafkaConfig `json:"kafka_config"`
+		Name           *string                `json:"name"`
+		Type           *string                `json:"type"`
+		Host           *string                `json:"host"`
+		Port           *int                   `json:"port"`
+		Database       *string                `json:"database"`
+		Username       *string                `json:"username"`
+		Tags           *[]string              `json:"tags"`
+		Password       *string                `json:"password"`
+		ReadOnly       *bool                  `json:"read_only"`
+		PostgresConfig *config.PostgresConfig `json:"postgres_config"`
+		RedisConfig    *config.RedisConfig    `json:"redis_config"`
+		KafkaConfig    *config.KafkaConfig    `json:"kafka_config"`
 	}
 
 	if !decodeJSON(w, r, &req) {
@@ -214,6 +229,27 @@ func (h *ConnectionsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 		existing.Password = encrypted
 	}
+	if req.PostgresConfig != nil {
+		incoming := req.PostgresConfig.Clone()
+		storedKey := ""
+		storedCert := ""
+		if existing.PostgresConfig != nil {
+			storedKey = existing.PostgresConfig.SSLClientKey
+			storedCert = existing.PostgresConfig.SSLClientCert
+		}
+		// A replaced certificate cannot be paired with the key kept from the old
+		// one — the handshake would fail later with a mismatch nobody can place.
+		if incoming.SSLClientCert != "" && incoming.SSLClientCert != storedCert && incoming.SSLClientKey == "" {
+			writeError(w, http.StatusBadRequest, "a new ssl client certificate must be sent with its private key")
+			return
+		}
+		if err := h.prepareClientKey(incoming, storedKey); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to encrypt ssl client key")
+			return
+		}
+		normalized := incoming.Normalize()
+		existing.PostgresConfig = &normalized
+	}
 	if req.RedisConfig != nil {
 		existing.RedisConfig = req.RedisConfig.Clone()
 		if existing.RedisConfig != nil {
@@ -230,6 +266,9 @@ func (h *ConnectionsHandler) Update(w http.ResponseWriter, r *http.Request) {
 			normalized := existing.KafkaConfig.Normalize()
 			existing.KafkaConfig = &normalized
 		}
+	}
+	if existing.Type != "postgres" {
+		existing.PostgresConfig = nil
 	}
 	if existing.Type != "redis" {
 		existing.RedisConfig = nil
@@ -460,6 +499,42 @@ func (h *ConnectionsHandler) managerFactory(connType string) (connector.Connecto
 	return h.manager.Factory(connType)
 }
 
+// prepareClientKey encrypts the TLS client key for storage, in place.
+//
+// An empty key means "keep the stored one": the key never travels back to the
+// browser, so a form the user did not re-fill has nothing to send. That is the
+// same rule the password follows, and it is what stops an edit of the port from
+// wiping the certificate.
+func (h *ConnectionsHandler) prepareClientKey(pgCfg *config.PostgresConfig, storedKey string) error {
+	if pgCfg == nil {
+		return nil
+	}
+	if pgCfg.SSLClientKey == "" {
+		pgCfg.SSLClientKey = storedKey
+		return nil
+	}
+
+	encrypted, err := config.Encrypt(h.cfg.EncryptionKey, pgCfg.SSLClientKey)
+	if err != nil {
+		return err
+	}
+	pgCfg.SSLClientKey = encrypted
+	return nil
+}
+
+// storedClientKey returns the encrypted client key already saved for a
+// connection, or "" when there is none to carry over.
+func (h *ConnectionsHandler) storedClientKey(id string) string {
+	if id == "" {
+		return ""
+	}
+	existing, ok := h.cfg.GetConnection(id)
+	if !ok || existing.PostgresConfig == nil {
+		return ""
+	}
+	return existing.PostgresConfig.SSLClientKey
+}
+
 func buildConnectionConfig(req connectionRequest, password string) config.ConnectionConfig {
 	cfg := config.ConnectionConfig{
 		ID:             req.ID,
@@ -473,6 +548,10 @@ func buildConnectionConfig(req connectionRequest, password string) config.Connec
 		Tags:           normalizeTags(req.Tags),
 		VisibleSchemas: normalizeVisibleSchemas(req.VisibleSchemas),
 		ReadOnly:       req.ReadOnly,
+	}
+	if req.PostgresConfig != nil {
+		normalized := req.PostgresConfig.Normalize()
+		cfg.PostgresConfig = &normalized
 	}
 	if req.RedisConfig != nil {
 		cfg.RedisConfig = req.RedisConfig.Clone()
@@ -503,8 +582,14 @@ func buildConnectionResponse(conn config.ConnectionConfig) connectionResponse {
 		Tags:           slices.Clone(conn.Tags),
 		VisibleSchemas: slices.Clone(conn.VisibleSchemas),
 		ReadOnly:       conn.ReadOnly,
+		PostgresConfig: conn.PostgresConfig.Clone(),
 		RedisConfig:    conn.RedisConfig.Clone(),
 		KafkaConfig:    conn.KafkaConfig.Clone(),
+	}
+	if resp.PostgresConfig != nil {
+		// The private key stays on the server. The certificate does not: it is not
+		// secret, and the form uses its presence to say a key is stored.
+		resp.PostgresConfig.SSLClientKey = ""
 	}
 	if conn.RedisConfig != nil {
 		resp.Mode = conn.RedisConfig.Mode
@@ -529,6 +614,12 @@ func validateConnectionRequest(req connectionRequest) error {
 	case "postgres":
 		if strings.TrimSpace(req.Host) == "" || req.Port <= 0 || strings.TrimSpace(req.Database) == "" || strings.TrimSpace(req.Username) == "" {
 			return fmt.Errorf("postgres requires host, port, database, and username")
+		}
+		// A CA is deliberately not required by verify-ca/verify-full: with none
+		// given the system trust store is used, which is the whole configuration
+		// for a managed database whose certificate is publicly signed.
+		if req.PostgresConfig != nil && !config.ValidSSLMode(req.PostgresConfig.Normalize().SSLMode) {
+			return fmt.Errorf("unsupported postgres ssl mode: %s", req.PostgresConfig.SSLMode)
 		}
 	case "redis":
 		redisCfg := config.RedisConfig{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,19 +9,20 @@ import (
 )
 
 type ConnectionConfig struct {
-	ID             string       `json:"id"`
-	Name           string       `json:"name"`
-	Type           string       `json:"type"` // "postgres", "redis", "kafka"
-	Host           string       `json:"host"`
-	Port           int          `json:"port"`
-	Database       string       `json:"database"`
-	Username       string       `json:"username"`
-	Password       string       `json:"password"` // encrypted
-	Tags           []string     `json:"tags,omitempty"`
-	VisibleSchemas []string     `json:"visible_schemas"`
-	ReadOnly       bool         `json:"read_only,omitempty"`
-	RedisConfig    *RedisConfig `json:"redis_config,omitempty"`
-	KafkaConfig    *KafkaConfig `json:"kafka_config,omitempty"`
+	ID             string          `json:"id"`
+	Name           string          `json:"name"`
+	Type           string          `json:"type"` // "postgres", "redis", "kafka"
+	Host           string          `json:"host"`
+	Port           int             `json:"port"`
+	Database       string          `json:"database"`
+	Username       string          `json:"username"`
+	Password       string          `json:"password"` // encrypted
+	Tags           []string        `json:"tags,omitempty"`
+	VisibleSchemas []string        `json:"visible_schemas"`
+	ReadOnly       bool            `json:"read_only,omitempty"`
+	PostgresConfig *PostgresConfig `json:"postgres_config,omitempty"`
+	RedisConfig    *RedisConfig    `json:"redis_config,omitempty"`
+	KafkaConfig    *KafkaConfig    `json:"kafka_config,omitempty"`
 }
 
 type LinkConfig struct {
@@ -76,6 +77,7 @@ func cloneConnection(conn ConnectionConfig) ConnectionConfig {
 	clone := conn
 	clone.Tags = slices.Clone(conn.Tags)
 	clone.VisibleSchemas = slices.Clone(conn.VisibleSchemas)
+	clone.PostgresConfig = conn.PostgresConfig.Clone()
 	clone.RedisConfig = conn.RedisConfig.Clone()
 	clone.KafkaConfig = conn.KafkaConfig.Clone()
 	return clone

--- a/internal/config/postgres.go
+++ b/internal/config/postgres.go
@@ -1,0 +1,70 @@
+package config
+
+import "strings"
+
+// PostgresSSLMode mirrors libpq's sslmode values. The names are libpq's on
+// purpose: this is the setting users already know from connection strings and
+// cloud consoles, and inventing our own vocabulary for it would only mean
+// translating it back in every error message.
+type PostgresSSLMode string
+
+const (
+	PostgresSSLDisable    PostgresSSLMode = "disable"
+	PostgresSSLPrefer     PostgresSSLMode = "prefer"
+	PostgresSSLRequire    PostgresSSLMode = "require"
+	PostgresSSLVerifyCA   PostgresSSLMode = "verify-ca"
+	PostgresSSLVerifyFull PostgresSSLMode = "verify-full"
+)
+
+// PostgresConfig stores PostgreSQL-specific connection settings.
+//
+// Certificate material is held inline as PEM rather than as file paths: the
+// config is a single JSON file that users move between machines and mount into
+// a container, and a path recorded on one host means nothing on the next.
+// SSLClientKey is a private key and is encrypted at rest exactly like Password.
+type PostgresConfig struct {
+	SSLMode       PostgresSSLMode `json:"ssl_mode,omitempty"`
+	SSLRootCert   string          `json:"ssl_root_cert,omitempty"`
+	SSLClientCert string          `json:"ssl_client_cert,omitempty"`
+	SSLClientKey  string          `json:"ssl_client_key,omitempty"` // encrypted
+	SSLServerName string          `json:"ssl_server_name,omitempty"`
+}
+
+// Clone returns a deep copy of the Postgres config.
+func (p *PostgresConfig) Clone() *PostgresConfig {
+	if p == nil {
+		return nil
+	}
+	clone := *p
+	return &clone
+}
+
+// Normalize trims the PEM fields and fills in the default mode without mutating
+// the receiver.
+//
+// The default is "disable", not libpq's "prefer", because every connection
+// stored before this setting existed connected without TLS. Reading an absent
+// mode as "prefer" would quietly change how those connect on the next restart.
+// New connections get their default from the wizard, which sends "prefer".
+func (p PostgresConfig) Normalize() PostgresConfig {
+	clone := p
+	clone.SSLMode = PostgresSSLMode(strings.TrimSpace(string(p.SSLMode)))
+	if clone.SSLMode == "" {
+		clone.SSLMode = PostgresSSLDisable
+	}
+	clone.SSLRootCert = strings.TrimSpace(p.SSLRootCert)
+	clone.SSLClientCert = strings.TrimSpace(p.SSLClientCert)
+	clone.SSLClientKey = strings.TrimSpace(p.SSLClientKey)
+	clone.SSLServerName = strings.TrimSpace(p.SSLServerName)
+	return clone
+}
+
+// ValidSSLMode reports whether mode is one this build understands. An empty
+// mode is valid and means the default.
+func ValidSSLMode(mode PostgresSSLMode) bool {
+	switch mode {
+	case "", PostgresSSLDisable, PostgresSSLPrefer, PostgresSSLRequire, PostgresSSLVerifyCA, PostgresSSLVerifyFull:
+		return true
+	}
+	return false
+}

--- a/internal/config/postgres_test.go
+++ b/internal/config/postgres_test.go
@@ -1,0 +1,64 @@
+package config
+
+import "testing"
+
+func TestPostgresConfigNormalize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   PostgresConfig
+		want PostgresConfig
+	}{
+		{
+			name: "empty mode keeps existing connections plaintext",
+			in:   PostgresConfig{},
+			want: PostgresConfig{SSLMode: PostgresSSLDisable},
+		},
+		{
+			name: "surrounding whitespace is trimmed off pasted PEM",
+			in:   PostgresConfig{SSLMode: " require ", SSLRootCert: "\n-----BEGIN CERTIFICATE-----\n", SSLServerName: " db.internal "},
+			want: PostgresConfig{SSLMode: PostgresSSLRequire, SSLRootCert: "-----BEGIN CERTIFICATE-----", SSLServerName: "db.internal"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.in.Normalize()
+			if got != tt.want {
+				t.Fatalf("got %+v want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgresConfigCloneIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	original := &PostgresConfig{SSLMode: PostgresSSLVerifyFull, SSLClientKey: "key"}
+	clone := original.Clone()
+	clone.SSLClientKey = "other"
+
+	if original.SSLClientKey != "key" {
+		t.Fatal("clone wrote through to the original")
+	}
+	if (*PostgresConfig)(nil).Clone() != nil {
+		t.Fatal("cloning nil should stay nil")
+	}
+}
+
+func TestValidSSLMode(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []PostgresSSLMode{"", PostgresSSLDisable, PostgresSSLPrefer, PostgresSSLRequire, PostgresSSLVerifyCA, PostgresSSLVerifyFull} {
+		if !ValidSSLMode(mode) {
+			t.Errorf("mode %q should be valid", mode)
+		}
+	}
+	for _, mode := range []PostgresSSLMode{"verify", "off", "TRUE"} {
+		if ValidSSLMode(mode) {
+			t.Errorf("mode %q should be rejected", mode)
+		}
+	}
+}

--- a/internal/connector/postgres/postgres.go
+++ b/internal/connector/postgres/postgres.go
@@ -2,12 +2,19 @@ package postgres
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/zxchlorka/kizuna/internal/config"
 	"github.com/zxchlorka/kizuna/internal/connector"
@@ -64,24 +71,129 @@ type schemaCacheBucket struct {
 	expires time.Time
 }
 
-// New creates a new PostgresConnector with a pgxpool connection pool.
-func New(ctx context.Context, cfg config.ConnectionConfig, encKey string) (*PostgresConnector, error) {
-	password := cfg.Password
-	if encKey != "" && password != "" {
-		decrypted, err := config.Decrypt(encKey, password)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt password: %w", err)
+// sslSettings returns the connection's TLS settings with defaults applied,
+// tolerating the nil config every connection stored before TLS support has.
+func sslSettings(cfg config.ConnectionConfig) config.PostgresConfig {
+	settings := config.PostgresConfig{}
+	if cfg.PostgresConfig != nil {
+		settings = *cfg.PostgresConfig
+	}
+	return settings.Normalize()
+}
+
+func decryptSecret(encKey, value string) (string, error) {
+	if encKey == "" || value == "" {
+		return value, nil
+	}
+	return config.Decrypt(encKey, value)
+}
+
+// dsnSSLMode is the mode handed to pgx, which is not always the mode the user
+// picked. libpq documents that sslmode=require with a root certificate present
+// verifies the chain, exactly as verify-ca does. pgx implements that rule by
+// looking at the sslrootcert *setting*, which we never set — our CA arrives as
+// inline PEM and is installed after parsing — so the upgrade is applied here
+// instead. Without it, supplying a CA and choosing require would verify nothing.
+func dsnSSLMode(ssl config.PostgresConfig) config.PostgresSSLMode {
+	if ssl.SSLMode == config.PostgresSSLRequire && ssl.SSLRootCert != "" {
+		return config.PostgresSSLVerifyCA
+	}
+	return ssl.SSLMode
+}
+
+// buildDSN assembles the connection URI. url.URL escapes the credentials, which
+// fmt.Sprintf did not: a password containing @, / or ? made the DSN parse as a
+// different host, or fail outright.
+func buildDSN(cfg config.ConnectionConfig, password string, ssl config.PostgresConfig) string {
+	dsn := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(cfg.Username, password),
+		Host:     net.JoinHostPort(resolveHost(cfg.Host), strconv.Itoa(cfg.Port)),
+		Path:     "/" + cfg.Database,
+		RawQuery: url.Values{"sslmode": {string(dsnSSLMode(ssl))}}.Encode(),
+	}
+	return dsn.String()
+}
+
+// applyTLSMaterial installs the certificate material pgx cannot take from a
+// DSN. pgx reads sslrootcert/sslcert/sslkey as paths to files on disk; we hold
+// PEM inline, so the config is parsed first — that is what decides each mode's
+// verification rules — and the material is filled in afterwards.
+//
+// Every TLS config the parse produced is covered, not only the first one:
+// sslmode=prefer becomes two connection attempts, one with TLS and a plaintext
+// fallback, and pgx keeps the remainder in Fallbacks. Filling in only
+// ConnConfig.TLSConfig would leave a fallback attempt without the CA.
+func applyTLSMaterial(connCfg *pgconn.Config, ssl config.PostgresConfig, clientKey string) error {
+	var rootCAs *x509.CertPool
+	if ssl.SSLRootCert != "" {
+		rootCAs = x509.NewCertPool()
+		if !rootCAs.AppendCertsFromPEM([]byte(ssl.SSLRootCert)) {
+			return errors.New("ssl root certificate is not valid PEM")
 		}
-		password = decrypted
 	}
 
-	host := resolveHost(cfg.Host)
-	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
-		cfg.Username, password, host, cfg.Port, cfg.Database)
+	var clientCerts []tls.Certificate
+	switch {
+	case ssl.SSLClientCert != "" && clientKey == "":
+		return errors.New("ssl client certificate needs its private key")
+	case ssl.SSLClientCert == "" && clientKey != "":
+		return errors.New("ssl client key needs its certificate")
+	case ssl.SSLClientCert != "":
+		pair, err := tls.X509KeyPair([]byte(ssl.SSLClientCert), []byte(clientKey))
+		if err != nil {
+			return fmt.Errorf("ssl client certificate and key do not load: %w", err)
+		}
+		clientCerts = []tls.Certificate{pair}
+	}
 
-	poolConfig, err := pgxpool.ParseConfig(dsn)
+	tlsConfigs := make([]*tls.Config, 0, len(connCfg.Fallbacks)+1)
+	if connCfg.TLSConfig != nil {
+		tlsConfigs = append(tlsConfigs, connCfg.TLSConfig)
+	}
+	for _, fallback := range connCfg.Fallbacks {
+		if fallback.TLSConfig != nil {
+			tlsConfigs = append(tlsConfigs, fallback.TLSConfig)
+		}
+	}
+
+	for _, tlsConfig := range tlsConfigs {
+		if rootCAs != nil {
+			// verify-ca verifies the chain inside a VerifyPeerCertificate closure
+			// that reads RootCAs off this same struct when the handshake runs, so
+			// assigning it here reaches that path too.
+			tlsConfig.RootCAs = rootCAs
+		}
+		if clientCerts != nil {
+			tlsConfig.Certificates = clientCerts
+		}
+		if ssl.SSLServerName != "" {
+			tlsConfig.ServerName = ssl.SSLServerName
+		}
+	}
+
+	return nil
+}
+
+// New creates a new PostgresConnector with a pgxpool connection pool.
+func New(ctx context.Context, cfg config.ConnectionConfig, encKey string) (*PostgresConnector, error) {
+	password, err := decryptSecret(encKey, cfg.Password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt password: %w", err)
+	}
+
+	ssl := sslSettings(cfg)
+	clientKey, err := decryptSecret(encKey, ssl.SSLClientKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt ssl client key: %w", err)
+	}
+
+	poolConfig, err := pgxpool.ParseConfig(buildDSN(cfg, password, ssl))
 	if err != nil {
 		return nil, normalizePostgresError(fmt.Errorf("failed to parse connection config: %w", err))
+	}
+	if err := applyTLSMaterial(&poolConfig.ConnConfig.Config, ssl, clientKey); err != nil {
+		return nil, normalizePostgresError(err)
 	}
 	poolConfig.ConnConfig.ConnectTimeout = 5 * time.Second
 

--- a/internal/connector/postgres/tls_integration_test.go
+++ b/internal/connector/postgres/tls_integration_test.go
@@ -1,0 +1,144 @@
+package postgres
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zxchlorka/kizuna/internal/config"
+)
+
+// Gated integration test for TLS. A unit test can prove the material lands on
+// the right tls.Config, but only a real server proves the modes mean what they
+// say: that verify-full rejects a certificate it cannot chain, that it rejects
+// a name the certificate was not issued for, and that the connection is
+// actually encrypted rather than quietly falling back.
+//
+// Skipped unless POSTGRES_TLS_TEST=1. When set, it ONLY ever targets the local
+// docker-compose.test.yml postgres-tls service (127.0.0.1:55433, dev/dev/devdb)
+// -- host, port and credentials are hardcoded to that fixture and never read
+// from the environment, so this can never reach a real database (see CLAUDE.md:
+// production connections are never to be used for testing).
+const (
+	tlsTestHost      = "127.0.0.1"
+	tlsTestPort      = 55433
+	tlsTestContainer = "kizuna-postgres-tls-1"
+)
+
+func tlsTestCA(t *testing.T) string {
+	t.Helper()
+	if os.Getenv("POSTGRES_TLS_TEST") != "1" {
+		t.Skip("set POSTGRES_TLS_TEST=1 with docker-compose.test.yml's postgres-tls service running to exercise this")
+	}
+
+	// The CA lives in the fixture's volume, not on the host.
+	out, err := exec.Command("docker", "exec", tlsTestContainer, "cat", "/certs/ca.crt").Output()
+	if err != nil {
+		t.Skipf("cannot read the fixture CA from %s: %v", tlsTestContainer, err)
+	}
+	return string(out)
+}
+
+func tlsTestConfig(ssl config.PostgresConfig) config.ConnectionConfig {
+	return config.ConnectionConfig{
+		ID:             "tls-test",
+		Type:           "postgres",
+		Host:           tlsTestHost,
+		Port:           tlsTestPort,
+		Database:       "devdb",
+		Username:       "dev",
+		Password:       "dev",
+		PostgresConfig: &ssl,
+	}
+}
+
+func TestPostgresTLSModes(t *testing.T) {
+	caPEM := tlsTestCA(t)
+
+	tests := []struct {
+		name      string
+		ssl       config.PostgresConfig
+		wantErr   string
+		wantEnc   bool
+		wantNoEnc bool
+	}{
+		{
+			name:      "disable stays in the clear",
+			ssl:       config.PostgresConfig{SSLMode: config.PostgresSSLDisable},
+			wantNoEnc: true,
+		},
+		{
+			name:    "prefer takes the TLS the server offers",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLPrefer},
+			wantEnc: true,
+		},
+		{
+			name:    "require encrypts without checking anything",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLRequire},
+			wantEnc: true,
+		},
+		{
+			name:    "require with the CA verifies the chain",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLRequire, SSLRootCert: caPEM},
+			wantEnc: true,
+		},
+		{
+			name:    "verify-full without the CA is refused",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLVerifyFull},
+			wantErr: "certificate",
+		},
+		{
+			name:    "verify-full with the CA connects",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLVerifyFull, SSLRootCert: caPEM},
+			wantEnc: true,
+		},
+		{
+			name:    "verify-full checks the name it was given",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLVerifyFull, SSLRootCert: caPEM, SSLServerName: "not-in-the-cert.example"},
+			wantErr: "not-in-the-cert.example",
+		},
+		{
+			name:    "verify-ca ignores the name",
+			ssl:     config.PostgresConfig{SSLMode: config.PostgresSSLVerifyCA, SSLRootCert: caPEM, SSLServerName: "not-in-the-cert.example"},
+			wantEnc: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			conn, err := New(ctx, tlsTestConfig(tt.ssl), "")
+			if tt.wantErr != "" {
+				if err == nil {
+					conn.Close()
+					t.Fatalf("expected the connection to be refused")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not mention %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("connect: %v", err)
+			}
+			defer conn.Close()
+
+			var encrypted bool
+			row := conn.pool.QueryRow(ctx, "SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+			if err := row.Scan(&encrypted); err != nil {
+				t.Fatalf("read pg_stat_ssl: %v", err)
+			}
+			if tt.wantEnc && !encrypted {
+				t.Error("connection is not encrypted")
+			}
+			if tt.wantNoEnc && encrypted {
+				t.Error("connection is encrypted but the mode was disable")
+			}
+		})
+	}
+}

--- a/internal/connector/postgres/tls_test.go
+++ b/internal/connector/postgres/tls_test.go
@@ -1,0 +1,227 @@
+package postgres
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/zxchlorka/kizuna/internal/config"
+)
+
+func TestBuildDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		conn     config.ConnectionConfig
+		password string
+		ssl      config.PostgresConfig
+		want     string
+	}{
+		{
+			name:     "plain",
+			conn:     config.ConnectionConfig{Host: "db.example", Port: 5432, Database: "app", Username: "reader"},
+			password: "secret",
+			ssl:      config.PostgresConfig{SSLMode: config.PostgresSSLDisable},
+			want:     "postgres://reader:secret@db.example:5432/app?sslmode=disable",
+		},
+		{
+			// The old fmt.Sprintf DSN broke here: the @ ended the userinfo early and
+			// pgx parsed "b" as the host.
+			name:     "password with separators is escaped",
+			conn:     config.ConnectionConfig{Host: "db.example", Port: 5432, Database: "app", Username: "reader"},
+			password: "a@b/c?d:e",
+			ssl:      config.PostgresConfig{SSLMode: config.PostgresSSLRequire},
+			want:     "postgres://reader:a%40b%2Fc%3Fd%3Ae@db.example:5432/app?sslmode=require",
+		},
+		{
+			name:     "ipv6 host is bracketed",
+			conn:     config.ConnectionConfig{Host: "::1", Port: 5432, Database: "app", Username: "reader"},
+			password: "p",
+			ssl:      config.PostgresConfig{SSLMode: config.PostgresSSLPrefer},
+			want:     "postgres://reader:p@[::1]:5432/app?sslmode=prefer",
+		},
+		{
+			name:     "require with a CA is handed to pgx as verify-ca",
+			conn:     config.ConnectionConfig{Host: "db.example", Port: 5432, Database: "app", Username: "reader"},
+			password: "p",
+			ssl:      config.PostgresConfig{SSLMode: config.PostgresSSLRequire, SSLRootCert: "-----BEGIN CERTIFICATE-----"},
+			want:     "postgres://reader:p@db.example:5432/app?sslmode=verify-ca",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildDSN(tt.conn, tt.password, tt.ssl)
+			if got != tt.want {
+				t.Fatalf("dsn mismatch:\n got %s\nwant %s", got, tt.want)
+			}
+			if _, err := pgxpool.ParseConfig(got); err != nil {
+				t.Fatalf("pgx cannot parse the dsn we build: %v", err)
+			}
+		})
+	}
+}
+
+func TestSSLSettingsDefaultsToDisable(t *testing.T) {
+	t.Parallel()
+
+	// Every connection stored before TLS existed has no postgres_config at all,
+	// and must keep connecting exactly as it did.
+	got := sslSettings(config.ConnectionConfig{Host: "db", Port: 5432})
+	if got.SSLMode != config.PostgresSSLDisable {
+		t.Fatalf("nil config should mean disable, got %q", got.SSLMode)
+	}
+}
+
+// TestApplyTLSMaterialCoversFallbacks pins the reason this code exists: sslmode
+// values that imply a retry produce several connection attempts, and material
+// installed on only the first one leaves the rest unverified.
+func TestApplyTLSMaterialCoversFallbacks(t *testing.T) {
+	t.Parallel()
+
+	caPEM, _ := testCertificate(t)
+
+	poolCfg, err := pgxpool.ParseConfig("postgres://u:p@db.example:5432/app?sslmode=prefer")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	ssl := config.PostgresConfig{SSLMode: config.PostgresSSLPrefer, SSLRootCert: caPEM, SSLServerName: "real.example"}
+	if err := applyTLSMaterial(&poolCfg.ConnConfig.Config, ssl, ""); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	checked := 0
+	if poolCfg.ConnConfig.TLSConfig != nil {
+		checked++
+		if poolCfg.ConnConfig.TLSConfig.RootCAs == nil {
+			t.Error("primary attempt has no CA pool")
+		}
+		if poolCfg.ConnConfig.TLSConfig.ServerName != "real.example" {
+			t.Errorf("primary attempt server name = %q", poolCfg.ConnConfig.TLSConfig.ServerName)
+		}
+	}
+	for i, fallback := range poolCfg.ConnConfig.Fallbacks {
+		if fallback.TLSConfig == nil {
+			continue // the plaintext attempt prefer falls back to
+		}
+		checked++
+		if fallback.TLSConfig.RootCAs == nil {
+			t.Errorf("fallback %d has no CA pool", i)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no TLS config was inspected; the test proves nothing")
+	}
+}
+
+func TestApplyTLSMaterialErrors(t *testing.T) {
+	t.Parallel()
+
+	caPEM, _ := testCertificate(t)
+	certPEM, keyPEM := testCertificate(t)
+
+	tests := []struct {
+		name      string
+		ssl       config.PostgresConfig
+		clientKey string
+		wantErr   string
+	}{
+		{
+			name:    "garbage CA",
+			ssl:     config.PostgresConfig{SSLRootCert: "not a certificate"},
+			wantErr: "not valid PEM",
+		},
+		{
+			name:    "certificate without key",
+			ssl:     config.PostgresConfig{SSLClientCert: certPEM},
+			wantErr: "needs its private key",
+		},
+		{
+			name:      "key without certificate",
+			ssl:       config.PostgresConfig{},
+			clientKey: keyPEM,
+			wantErr:   "needs its certificate",
+		},
+		{
+			name:      "mismatched pair",
+			ssl:       config.PostgresConfig{SSLClientCert: caPEM},
+			clientKey: keyPEM,
+			wantErr:   "do not load",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			poolCfg, err := pgxpool.ParseConfig("postgres://u:p@db.example:5432/app?sslmode=require")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			err = applyTLSMaterial(&poolCfg.ConnConfig.Config, tt.ssl, tt.clientKey)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApplyTLSMaterialAcceptsAPair(t *testing.T) {
+	t.Parallel()
+
+	certPEM, keyPEM := testCertificate(t)
+	poolCfg, err := pgxpool.ParseConfig("postgres://u:p@db.example:5432/app?sslmode=require")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	ssl := config.PostgresConfig{SSLMode: config.PostgresSSLRequire, SSLClientCert: certPEM}
+	if err := applyTLSMaterial(&poolCfg.ConnConfig.Config, ssl, keyPEM); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if len(poolCfg.ConnConfig.TLSConfig.Certificates) != 1 {
+		t.Fatalf("client certificate not installed")
+	}
+}
+
+// testCertificate returns a self-signed certificate and its key, both PEM.
+func testCertificate(t *testing.T) (certPEM, keyPEM string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "kizuna-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+		string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+}


### PR DESCRIPTION
Postgres connections could only be made in the clear: the DSN was assembled with
`sslmode=disable` hardcoded, which ruled out most managed, staging and production
databases. This adds the full set of libpq modes and the certificate material to
go with them.

## What is in it

- `disable`, `prefer`, `require`, `verify-ca`, `verify-full`, chosen in the
  connection form.
- CA and client certificate held inline as PEM rather than as file paths. The
  config is one JSON file that gets moved between machines and mounted into a
  container, where a recorded path means nothing.
- The client key is encrypted with the same AES-256-GCM used for the password,
  never returned to the browser, and kept when a form is saved without re-typing
  it.
- An optional server name, for verifying a certificate when the host dialled is
  a tunnel, an IP or a proxy.
- A pasted connection string that names an `sslmode` now applies it.

## Two decisions worth reviewing

**`require` with a CA verifies the chain.** libpq documents that behaviour, and
pgx implements it by inspecting the `sslrootcert` *setting* — which is never set
here, because the CA arrives as inline PEM and is installed after parsing. The
mode handed to pgx is upgraded to `verify-ca` instead, so supplying a CA and
choosing `require` does not silently verify nothing.

**`verify-ca` and `verify-full` do not require a CA.** With none given the system
trust store is used, which is the entire configuration for a managed database
whose certificate is publicly signed. Demanding a PEM there would block a valid
setup.

## Compatibility

A stored connection with no `postgres_config` reads as `disable`, so everything
saved before this keeps connecting exactly as it did. New connections default to
`prefer` in the wizard.

## Fixed along the way

The DSN was built with `fmt.Sprintf` and a raw password, so `@`, `/` or `?` in a
password ended the credentials early and changed which host was dialled. It is
now assembled through `url.URL`, with the escaping pinned by a test.

## Verification

- Unit tests for the DSN, the mode upgrade, and the certificate material landing
  on every TLS config the parse produces — `sslmode=prefer` yields two connection
  attempts, and filling in only the first leaves the fallback unverified.
- `docker-compose.test.yml` gains a TLS Postgres on 55433 with certificates
  generated once into a named volume. `POSTGRES_TLS_TEST=1 go test ./internal/connector/postgres/`
  exercises eight modes against it: `verify-full` is refused without the CA,
  refused with a server name the certificate was not issued for, and connects
  with the CA; `disable` stays in the clear; the rest report TLSv1.3 through
  `pg_stat_ssl`.
