### PR TITLE
Deep links, Redis rename, Kafka key/header search, row SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,68 @@
 Notable changes per release. Each heading matches a git tag, so `git show v0.5.0`
 gives the same notes from the command line.
 
+## v0.8.0 — 2026-08-19
+
+### Postgres
+
+- Connections can use TLS, from `prefer` through `verify-full`, with the CA and
+  an optional client certificate pasted in as PEM rather than named as files on
+  disk — a path recorded on one machine means nothing in the container the
+  config is mounted into. The private key is encrypted alongside the password
+  and is never sent back to the browser.
+- `require` with a CA given verifies the chain, as libpq documents; `verify-ca`
+  and `verify-full` fall back to the system trust store when no CA is supplied,
+  which is the whole configuration for a managed database with a publicly
+  signed certificate. A connection saved before any of this existed keeps
+  connecting exactly as it did.
+- A pasted connection string that names an `sslmode` now sets it, instead of
+  filling the rest of the form and leaving the connection in the clear.
+- A password containing `@`, `/` or `?` no longer changes which host is dialled.
+  The connection string was assembled by hand and those characters ended the
+  credentials early.
+- One row can be copied as a `SELECT`, `INSERT`, `UPDATE` or `DELETE`. The two
+  destructive statements are written only against a complete primary key —
+  without one they are not offered, since a `WHERE` over ordinary columns looks
+  just as precise and can match rows nobody looked at.
+
+### Redis
+
+- A key can be renamed. An existing name is refused rather than overwritten,
+  which is what Redis's own RENAME does silently. In a cluster, where a rename
+  across hash slots is impossible, the key is copied to the new slot and the old
+  one dropped; the copy happens first, so an interruption leaves the original
+  in place.
+- A link that reads a key's value can be followed from that value, and every
+  link a key can be walked along is shown beneath its name. Previously both
+  required opening the Links menu, so a link just created looked like one that
+  had not been saved.
+- A key's link menu is about that key alone. What else the connection is wired
+  to moved to the tab bar, beside Overview.
+- The key header keeps the pencil on the name it renames; refresh, duplicate and
+  delete are icons with hover labels. The type, connection and mode panels are
+  gone — the type was already a badge, and the other two belong to the
+  connection, which now names itself once in the tab bar.
+
+### Kafka
+
+- Messages can be searched by record key or by a header, not only by a path into
+  the payload. Both are strings the broker delivers beside the value, so they
+  match on a record whose body is binary or never parses as JSON — which is much
+  of what a search by correlation id is for.
+- Conditions take a `contains` comparison in addition to `equals`, on the key, a
+  header, or a payload field.
+
+### Workspace
+
+- The address bar carries the open object and any filters applied to it, so an
+  investigation can be handed to someone else as a link. Opening one restores
+  the object and its filters; browser Back and Forward walk the objects visited.
+
+### Removed
+
+- `schema_registry_url` is gone from the connection type. It was declared but
+  nothing ever read it, so it promised decoding the product does not do.
+
 ## v0.7.0 — 2026-08-16
 
 ### Postgres

--- a/frontend/src/components/PgTableView.tsx
+++ b/frontend/src/components/PgTableView.tsx
@@ -13,7 +13,6 @@ import { FkBreadcrumb } from '@/components/Navigation/FkBreadcrumb'
 import { CreateLinkDialog } from '@/components/links/CreateLinkDialog'
 import {
   LINK_MENU_CAP,
-  LINK_PREVIEW_CAP,
   LinkPickerDialog,
   type LinkPickerItem,
 } from '@/components/links/LinkPickerDialog'
@@ -29,12 +28,10 @@ import { useLinksStore } from '@/stores/links'
 import { useOpenLinkSource, useOpenLinkTarget } from '@/hooks/useOpenLink'
 import {
   canReverse,
-  connectionLinks,
   extractPgColumn,
   linkSourceLabel,
   linkSummary,
   linkTargetLabel,
-  linkTouchesObject,
 } from '@/lib/links'
 import { classifyDataLoadError } from '@/lib/data-load-errors'
 import { clipboardFailureMessage, writeClipboardText } from '@/lib/clipboard'
@@ -148,7 +145,7 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
     { x: number; y: number; row: TableRow; column?: string; value?: unknown } | null
   >(null)
   const [createLinkOpen, setCreateLinkOpen] = useState(false)
-  const [pickerGroup, setPickerGroup] = useState<'table' | 'reverse' | 'connection' | null>(null)
+  const [pickerGroup, setPickerGroup] = useState<'table' | 'reverse' | null>(null)
   // rowKey -> the row's PK predicate AND the row itself.
   //
   // Selection survives paging on purpose (Delete selected has always acted on
@@ -213,16 +210,6 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
     [links, connId, object]
   )
 
-  // Everything else wired up on this connection. Membership is decided by what
-  // the link mentions, never by whether it happens to be navigable -- see
-  // linkTouchesObject.
-  const otherConnectionLinks = useMemo(
-    () => connectionLinks(links, connId, links.filter((link) => linkTouchesObject(link, connId, object, 'postgres'))),
-    [links, connId, object]
-  )
-  // The dialog answers "everything on this connection", so it lists them all.
-  const allConnectionLinks = useMemo(() => connectionLinks(links, connId), [links, connId])
-
 
   useEffect(() => {
     void (async () => {
@@ -273,16 +260,6 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
         }
       })
     }
-    if (pickerGroup === 'connection') {
-      // Reference only: these belong to other tables, so this row holds no
-      // value to follow them with.
-      return allConnectionLinks.map((link) => ({
-        id: link.id,
-        label: linkSummary(link, connectionName),
-        disabled: true,
-        onPick: () => undefined,
-      }))
-    }
     return []
   }, [
     pickerGroup,
@@ -290,8 +267,6 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
     columns,
     tableLinks,
     reverseLinks,
-    allConnectionLinks,
-    connectionName,
     openLinkTarget,
     openLinkSource,
   ])
@@ -1234,26 +1209,8 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
               {linkSummary(link, connectionName)}
             </FloatingMenuItem>
           ))}
-          {/* What else this connection is wired to. Reference only -- these
-              belong to other tables, so this row has no value to follow them
-              with -- but without them a table with no links of its own looked
-              like a connection with none. */}
-          {/* The separator belongs to the whole connection block, not just its
-              preview: when every link on the connection is already listed above,
-              the preview is empty but "Show all" still needs to stand apart from
-              the group before it. */}
-          {allConnectionLinks.length > 0 && <FloatingMenuSeparator />}
-          {otherConnectionLinks.length > 0 && <FloatingMenuLabel>Elsewhere on this connection</FloatingMenuLabel>}
-          {otherConnectionLinks.slice(0, LINK_PREVIEW_CAP).map((link: LinkRecord) => (
-            <FloatingMenuItem key={`conn-${link.id}`} disabled>
-              {linkSummary(link, connectionName)}
-            </FloatingMenuItem>
-          ))}
-          {allConnectionLinks.length > 0 && (
-            <FloatingMenuItem onClick={() => setPickerGroup('connection')}>
-              {`Show all ${allConnectionLinks.length} on this connection…`}
-            </FloatingMenuItem>
-          )}
+          {/* What else the connection is wired to belongs to the connection,
+              not to this row: the full list sits beside Overview. */}
           <FloatingMenuSeparator />
           <FloatingMenuItem
             onClick={() => {
@@ -1274,8 +1231,6 @@ export function PgTableView({ connId, object, tabId }: PgTableViewProps) {
         title={
           pickerGroup === 'reverse'
             ? 'Back to source'
-            : pickerGroup === 'connection'
-            ? 'Links on this connection'
             : 'Open linked record'
         }
         items={pickerItems}

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -624,7 +624,25 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                 </div>
                 <div className="min-w-0">
                   <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Redis key</div>
-                  <h2 className="mt-1 truncate font-mono text-lg font-semibold text-foreground">{object}</h2>
+                  {/* Renaming edits this name, so the pencil sits on it rather
+                      than in the row of actions on the far side of the header. */}
+                  <div className="mt-1 flex min-w-0 items-center gap-1.5">
+                    <h2 className="truncate font-mono text-lg font-semibold text-foreground">{object}</h2>
+                    {!readOnly && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 shrink-0 p-0 text-muted-foreground hover:text-foreground"
+                        onClick={() => setRenameOpen(true)}
+                        disabled={saving || renaming}
+                        title="Rename"
+                        aria-label="Rename key"
+                      >
+                        <PenLine className="h-3.5 w-3.5" />
+                      </Button>
+                    )}
+                  </div>
                   <div className="mt-2 flex flex-wrap items-center gap-2">
                     <span className={cn('inline-flex items-center rounded-sm border px-2 py-1 text-[10px] uppercase tracking-[0.14em]', getRedisTypePillClass(metaType ?? objectType))}>
                       {getRedisObjectTypeLabel(metaType ?? objectType)}
@@ -799,9 +817,21 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
-                <Button type="button" variant="outline" size="sm" className="h-8 gap-1.5" onClick={() => void refresh()} disabled={loading || saving}>
+                {/* Icons only past this point: the header already carries the
+                    key, its type, its size and its TTL, and five labelled
+                    buttons beside all of that read as noise. Links keeps its
+                    word — it opens a menu rather than doing something. */}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8 w-8 p-0"
+                  onClick={() => void refresh()}
+                  disabled={loading || saving}
+                  title="Refresh"
+                  aria-label="Refresh key"
+                >
                   <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
-                  Refresh
                 </Button>
                 {readOnly ? (
                   <span className="inline-flex items-center gap-1.5 rounded-sm border border-amber-500/30 bg-amber-500/5 px-2 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-amber-600 dark:text-amber-400">
@@ -816,31 +846,29 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                       type="button"
                       variant="outline"
                       size="sm"
-                      className="h-8 gap-1.5"
+                      className="h-8 w-8 p-0"
                       onClick={() => {
                         setCopyName(`${object}-copy`)
                         setCopyOpen(true)
                       }}
                       disabled={saving}
+                      title="Duplicate"
+                      aria-label="Duplicate key"
                     >
                       <CopyIcon className="h-3.5 w-3.5" />
-                      Duplicate
                     </Button>
                     <Button
                       type="button"
-                      variant="outline"
+                      variant="destructive"
                       size="sm"
-                      className="h-8 gap-1.5"
-                      onClick={() => setRenameOpen(true)}
-                      disabled={saving || renaming}
+                      className="h-8 w-8 p-0"
+                      onClick={() => setDeleteDialogOpen(true)}
+                      disabled={saving}
+                      title="Delete key"
+                      aria-label="Delete key"
                     >
-                      <PenLine className="h-3.5 w-3.5" />
-                      Rename
+                      <Trash2 className="h-3.5 w-3.5" />
                     </Button>
-                  <Button type="button" variant="destructive" size="sm" className="h-8 gap-1.5" onClick={() => setDeleteDialogOpen(true)} disabled={saving}>
-                    <Trash2 className="h-3.5 w-3.5" />
-                    Delete key
-                  </Button>
                   </>
                 )}
               </div>

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -33,12 +33,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { CreateLinkDialog } from '@/components/links/CreateLinkDialog'
-import {
-  LINK_MENU_CAP,
-  LINK_PREVIEW_CAP,
-  LinkPickerDialog,
-  type LinkPickerItem,
-} from '@/components/links/LinkPickerDialog'
+import { LINK_MENU_CAP, LinkPickerDialog, type LinkPickerItem } from '@/components/links/LinkPickerDialog'
 import {
   FloatingMenu,
   FloatingMenuItem,
@@ -49,14 +44,12 @@ import { useOpenLinkSource, useOpenLinkTarget } from '@/hooks/useOpenLink'
 import {
   canReverse,
   captureFromKey,
-  connectionLinks,
   extractRedisValue,
   isPerElementExtract,
   keyLevelRedisLinks,
   linkSourceLabel,
   linkSummary,
   linkTargetLabel,
-  linkTouchesObject,
   memberRedisLinks,
   redisKeyMatchesPattern,
   selectionRedisLinks,
@@ -78,15 +71,6 @@ interface RedisKeyViewProps {
   object: string
   objectType: ObjectType
   ttlSeconds?: number | null
-}
-
-function metaCard(label: string, value: string, accentClass: string) {
-  return (
-    <div className="rounded-sm border border-border bg-muted/10 px-3 py-3">
-      <div className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">{label}</div>
-      <div className={cn('mt-2 font-mono text-sm', accentClass)}>{value}</div>
-    </div>
-  )
 }
 
 export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: RedisKeyViewProps) {
@@ -169,7 +153,7 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
   // и поле, по которому кликнули.
   const [createFromElement, setCreateFromElement] = useState<{ field?: string } | null>(null)
   const [pickerGroup, setPickerGroup] = useState<
-    'key' | 'reverse' | 'perElement' | 'connection' | 'member' | 'selection' | null
+    'key' | 'reverse' | 'perElement' | 'member' | 'selection' | null
   >(null)
 
   useEffect(() => {
@@ -261,17 +245,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
     [links, connId, object]
   )
 
-  // Everything else wired up on this connection. Without it a key that simply
-  // has no links of its own showed a menu with nothing but "+ Create link…",
-  // which reads as "this connection has none" rather than "none apply here".
-  // Membership is decided by what the link mentions, never by whether it is
-  // navigable -- see linkTouchesObject. Using reverseLinks (already narrowed by
-  // canReverse) put links pointing straight at this key under "elsewhere".
-  const otherConnectionLinks = useMemo(
-    () => connectionLinks(links, connId, links.filter((link) => linkTouchesObject(link, connId, object, 'redis'))),
-    [links, connId, object]
-  )
-
   // Point at this key but cannot be walked back to their source: shown, not followed.
   const inboundOnlyLinks = useMemo(
     () =>
@@ -284,10 +257,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
       ),
     [links, connId, object]
   )
-  // The dialog answers "everything on this connection", so it lists the whole
-  // set -- including the links the menu already showed as actionable.
-  const allConnectionLinks = useMemo(() => connectionLinks(links, connId), [links, connId])
-
   const rows = useMemo(() => tabData?.rows ?? [], [tabData?.rows])
   const stringValue = useMemo(() => stringifyRedisValue(rows[0]?.value), [rows])
 
@@ -328,16 +297,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
         onPick: () => undefined,
       }))
     }
-    if (pickerGroup === 'connection') {
-      // Reference only: these describe wiring elsewhere on the connection, so
-      // there is no value here to follow them with.
-      return allConnectionLinks.map((link) => ({
-        id: link.id,
-        label: linkSummary(link, connectionName),
-        disabled: true,
-        onPick: () => undefined,
-      }))
-    }
     if (pickerGroup === 'member' && memberMenu) {
       const member = memberMenu.member
       return memberLinks.map((link) => ({
@@ -369,8 +328,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
     keyLinks,
     reverseLinks,
     perElementLinks,
-    allConnectionLinks,
-    connectionName,
     memberLinks,
     elementSelectionLinks,
     memberMenu,
@@ -783,35 +740,13 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                         </span>
                       </DropdownMenuItem>
                     ))}
-                    {/* What else this connection is wired to. Reference only --
-                        these belong to other keys, so there is no value here to
-                        follow them with -- but without them a key with no links
-                        of its own looked like a connection with none. */}
-                    {/* The separator belongs to the whole connection block, not
-                        just its preview: when every link on the connection is
-                        already listed above, the preview is empty but "Show all"
-                        still needs to stand apart. */}
-                    {allConnectionLinks.length > 0 && <DropdownMenuSeparator />}
-                    {otherConnectionLinks.length > 0 && (
-                      <div className="px-2 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
-                        Elsewhere on this connection
-                      </div>
-                    )}
-                    {otherConnectionLinks.slice(0, LINK_PREVIEW_CAP).map((link) => (
-                      <DropdownMenuItem key={`conn-${link.id}`} disabled className="font-mono text-xs">
-                        <span className="block min-w-0 max-w-[32rem] truncate">
-                          {linkSummary(link, connectionName)}
-                        </span>
-                      </DropdownMenuItem>
-                    ))}
-                    {allConnectionLinks.length > 0 && (
-                      <DropdownMenuItem className="font-mono text-xs" onClick={() => setPickerGroup('connection')}>
-                        {`Show all ${allConnectionLinks.length} on this connection…`}
-                      </DropdownMenuItem>
-                    )}
-                    {(keyLinks.length > 0 || perElementLinks.length > 0 || allConnectionLinks.length > 0) && (
-                      <DropdownMenuSeparator />
-                    )}
+                    {/* What else the connection is wired to is not asked about
+                        here — this menu is about this key. The whole list lives
+                        beside Overview, where the connection's other facts are. */}
+                    {(keyLinks.length > 0 ||
+                      reverseLinks.length > 0 ||
+                      perElementLinks.length > 0 ||
+                      inboundOnlyLinks.length > 0) && <DropdownMenuSeparator />}
                     <DropdownMenuItem className="font-mono text-xs" onClick={() => setCreateLinkOpen(true)}>
                       + Create link…
                     </DropdownMenuItem>
@@ -874,11 +809,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
               </div>
             </div>
 
-            <div className="grid gap-3 border-b border-border px-4 py-4 sm:grid-cols-3">
-              {metaCard('Type', getRedisObjectTypeLabel(metaType ?? objectType), 'text-foreground')}
-              {metaCard('Connection', connection?.name ?? connId, 'text-foreground')}
-              {metaCard('Mode', connection?.mode ?? 'standalone', 'text-foreground')}
-            </div>
           </div>
 
           {Boolean(meta.truncated) && (
@@ -1050,8 +980,6 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
             ? 'Back to source'
             : pickerGroup === 'perElement'
             ? 'Per-element links (right-click a value)'
-            : pickerGroup === 'connection'
-            ? `Links on ${connection?.name ?? connId}`
             : pickerGroup === 'selection'
             ? `Open from "${memberMenu?.token ?? ''}"`
             : pickerGroup === 'member'

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -34,6 +34,10 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { CreateLinkDialog } from '@/components/links/CreateLinkDialog'
 import { LINK_MENU_CAP, LinkPickerDialog, type LinkPickerItem } from '@/components/links/LinkPickerDialog'
+
+// Chips are a glance at where a key leads, not the list of everywhere it does —
+// the Links menu stays the place for that.
+const LINK_CHIP_CAP = 2
 import {
   FloatingMenu,
   FloatingMenuItem,
@@ -54,6 +58,7 @@ import {
   redisKeyMatchesPattern,
   selectionRedisLinks,
   suggestKeyPattern,
+  valueRedisLinks,
 } from '@/lib/links'
 import { trimToken, valueAtPoint } from '@/lib/textSelection'
 import { formatBytes } from '@/lib/numberFormat'
@@ -165,6 +170,10 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
   }, [fetchLinks])
 
   const keyLinks = useMemo(() => keyLevelRedisLinks(links, connId, object), [links, connId, object])
+  // Links that read the value rather than the key name. They belong on a click
+  // into the value: the header menu could already follow them, but nothing on
+  // the value itself said so, so a link just created looked like it had not been.
+  const valueLinks = useMemo(() => valueRedisLinks(links, connId, object), [links, connId, object])
   const memberLinks = useMemo(() => memberRedisLinks(links, connId, object), [links, connId, object])
 
   const [memberMenu, setMemberMenu] = useState<{
@@ -259,6 +268,16 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
   )
   const rows = useMemo(() => tabData?.rows ?? [], [tabData?.rows])
   const stringValue = useMemo(() => stringifyRedisValue(rows[0]?.value), [rows])
+
+  // Key-level links paired with the value they resolve to right now. A link
+  // whose value cannot be read here is left out rather than shown dead.
+  const followableLinks = useMemo(
+    () =>
+      keyLinks
+        .map((link) => ({ link, value: extractRedisValue(link, object, stringValue, rows) }))
+        .filter((entry): entry is { link: (typeof keyLinks)[number]; value: string } => entry.value !== null),
+    [keyLinks, object, stringValue, rows]
+  )
 
   // Полный список группы для модалки: в меню помещается только LINK_MENU_CAP
   // пунктов, здесь — всё, с полными метками.
@@ -642,6 +661,37 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                       </span>
                     )}
                   </div>
+
+                  {/* Where this key leads, on the key itself. A link used to be
+                      visible only after opening the Links menu, so one just
+                      created read as one that had not been saved. Only links
+                      that resolve to a value are shown — a chip that cannot be
+                      followed would be the same false signal in reverse. */}
+                  {followableLinks.length > 0 && (
+                    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                      {followableLinks.slice(0, LINK_CHIP_CAP).map(({ link, value }) => (
+                        <button
+                          key={`chip-${link.id}`}
+                          type="button"
+                          onClick={() => openLinkTarget(link, value)}
+                          title={linkSummary(link, connectionName)}
+                          className="inline-flex min-w-0 max-w-[22rem] items-center gap-1 rounded-sm border border-violet-500/30 bg-violet-500/5 px-2 py-1 font-mono text-[10px] text-violet-600 transition-colors hover:bg-violet-500/10 dark:text-violet-400"
+                        >
+                          <Link2 className="h-3 w-3 shrink-0" />
+                          <span className="truncate">{linkTargetLabel(link, value)}</span>
+                        </button>
+                      ))}
+                      {followableLinks.length > LINK_CHIP_CAP && (
+                        <button
+                          type="button"
+                          onClick={() => setPickerGroup('key')}
+                          className="rounded-sm px-1 font-mono text-[10px] text-muted-foreground hover:text-foreground"
+                        >
+                          {`+${followableLinks.length - LINK_CHIP_CAP} more`}
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -913,6 +963,28 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
 
       {memberMenu && (
         <FloatingMenu x={memberMenu.x} y={memberMenu.y} onClose={() => setMemberMenu(null)}>
+          {/* A link that reads the value is followed from the value. It resolves
+              against the whole value, not the click position, so it is offered
+              whether or not a word happens to be under the cursor. */}
+          {valueLinks.length > 0 && <FloatingMenuLabel>Open from this value</FloatingMenuLabel>}
+          {valueLinks.slice(0, LINK_MENU_CAP).map((link) => {
+            const value = extractRedisValue(link, object, stringValue, rows)
+            return (
+              <FloatingMenuItem
+                key={`val-${link.id}`}
+                disabled={value === null}
+                onClick={() => {
+                  if (value !== null) {
+                    openLinkTarget(link, value)
+                    setMemberMenu(null)
+                  }
+                }}
+              >
+                {value === null ? `${linkTargetLabel(link, null)} (no value)` : linkTargetLabel(link, value)}
+              </FloatingMenuItem>
+            )
+          })}
+          {valueLinks.length > 0 && memberLinks.length > 0 && <FloatingMenuSeparator />}
           {memberLinks.length > 0 && <FloatingMenuLabel>Open from element</FloatingMenuLabel>}
           {memberLinks.slice(0, LINK_MENU_CAP).map((link) => (
             <FloatingMenuItem
@@ -957,7 +1029,9 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
             </FloatingMenuItem>
           )}
 
-          {(memberLinks.length > 0 || elementSelectionLinks.length > 0) && <FloatingMenuSeparator />}
+          {(valueLinks.length > 0 || memberLinks.length > 0 || elementSelectionLinks.length > 0) && (
+            <FloatingMenuSeparator />
+          )}
           <FloatingMenuItem
             onClick={() => {
               setCreateFromElement({ field: memberMenu.field })

--- a/frontend/src/components/RedisKeyView.tsx
+++ b/frontend/src/components/RedisKeyView.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useState, type MouseEvent } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { Binary, Copy as CopyIcon, KeyRound, Link2, Lock, RefreshCw, TimerReset, Trash2 } from 'lucide-react'
+import { Binary, Copy as CopyIcon, KeyRound, Link2, Lock, PenLine, RefreshCw, TimerReset, Trash2 } from 'lucide-react'
 import { EmptyState } from '@/components/EmptyState'
 import { ErrorBanner } from '@/components/ErrorBanner'
 import { LoadingSkeleton } from '@/components/LoadingSkeleton'
 import { DeleteKeyDialog } from '@/components/redis/DeleteKeyDialog'
+import { RenameKeyDialog } from '@/components/redis/RenameKeyDialog'
 import { SetTTLDialog } from '@/components/redis/SetTTLDialog'
 import { HashEditor } from '@/components/redis/editors/HashEditor'
 import { JsonEditor } from '@/components/redis/editors/JsonEditor'
@@ -112,6 +113,32 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
   const [copyOpen, setCopyOpen] = useState(false)
   const [copyName, setCopyName] = useState('')
   const [copying, setCopying] = useState(false)
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [renaming, setRenaming] = useState(false)
+
+  // The key under this tab stops existing, so the tab has to follow it: the new
+  // name is opened first and the old tab closed after, which leaves the new one
+  // active instead of dropping the user onto a neighbouring tab.
+  const renameKey = async (destination: string) => {
+    if (renaming) {
+      return
+    }
+    setRenaming(true)
+    try {
+      await mutate(connId, { type: 'rename', object, schema: '', where: {}, data: { destination } }, tabId, {
+        reload: false,
+      })
+      setRenameOpen(false)
+      pushToast({ tone: 'success', title: 'Key renamed', message: destination })
+      openTab(connId, destination, objectType)
+      closeTab(tabId)
+      await refreshTree(connId)
+    } catch (error) {
+      pushToast({ tone: 'error', title: 'Rename failed', message: (error as Error).message })
+    } finally {
+      setRenaming(false)
+    }
+  }
 
   // The copy is made server-side from the stored value, so the new key is a
   // faithful duplicate of whatever type this is — no reading the contents into
@@ -799,6 +826,17 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
                       <CopyIcon className="h-3.5 w-3.5" />
                       Duplicate
                     </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5"
+                      onClick={() => setRenameOpen(true)}
+                      disabled={saving || renaming}
+                    >
+                      <PenLine className="h-3.5 w-3.5" />
+                      Rename
+                    </Button>
                   <Button type="button" variant="destructive" size="sm" className="h-8 gap-1.5" onClick={() => setDeleteDialogOpen(true)} disabled={saving}>
                     <Trash2 className="h-3.5 w-3.5" />
                     Delete key
@@ -878,6 +916,14 @@ export function RedisKeyView({ connId, tabId, object, objectType, ttlSeconds }: 
           </div>
         </DialogContent>
       </Dialog>
+
+      <RenameKeyDialog
+        open={renameOpen}
+        keyName={object}
+        saving={renaming}
+        onOpenChange={setRenameOpen}
+        onConfirm={renameKey}
+      />
 
       <DeleteKeyDialog
         open={deleteDialogOpen}

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,6 +1,7 @@
 import { Activity, Braces, CircleDot, Database, Eye, Folder, Gauge, Hash, List, ListOrdered, Plus, SquareTerminal, Table2, TerminalSquare, X, Zap } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { ConnectionLinksButton } from '@/components/links/ConnectionLinksButton'
 import { useConnectionStore } from '@/stores/connections'
 import { tabPageId, useWorkspaceStore } from '@/stores/workspace'
 import { isRedisObjectType } from '@/lib/objectTypes'
@@ -98,6 +99,16 @@ export function TabBar({ connId }: TabBarProps) {
       </div>
       {isKafka ? null : isRedis ? (
         <>
+          {/* Which server this is, and how it is wired, belong to the
+              connection — not to every key opened on it. */}
+          <span
+            className="hidden shrink-0 truncate font-mono text-[11px] text-muted-foreground md:inline"
+            title="The connection these tabs read from"
+          >
+            {connection?.name}
+            <span className="opacity-50"> · {connection?.mode ?? 'standalone'}</span>
+          </span>
+          <ConnectionLinksButton connId={connId} />
           <Button
             type="button"
             size="sm"
@@ -123,6 +134,7 @@ export function TabBar({ connId }: TabBarProps) {
         </>
       ) : (
         <>
+          <ConnectionLinksButton connId={connId} />
           <Button
             type="button"
             size="sm"

--- a/frontend/src/components/kafka/KafkaFilterDialog.tsx
+++ b/frontend/src/components/kafka/KafkaFilterDialog.tsx
@@ -72,7 +72,7 @@ export function KafkaFilterDialog({
 
         <div className="flex max-h-[50vh] flex-col gap-2 overflow-y-auto">
           {rows.map((condition, index) => (
-            <div key={index} className="flex flex-wrap items-center gap-2">
+            <div key={index} className="flex items-center gap-2">
               <span className="w-8 shrink-0 font-mono text-[11px] text-muted-foreground">
                 {index === 0 ? '' : mode === 'or' ? 'or' : 'and'}
               </span>
@@ -98,37 +98,43 @@ export function KafkaFilterDialog({
                   </SelectItem>
                 </SelectContent>
               </Select>
-              {/* The key is a single value with no name to give, so the field
-                  box has nothing to hold for it. */}
-              <input
-                value={conditionTarget(condition) === 'key' ? '' : condition.field}
-                onChange={(event) => update(index, { field: event.target.value })}
-                placeholder={
-                  conditionTarget(condition) === 'header'
-                    ? 'header name'
-                    : conditionTarget(condition) === 'key'
-                      ? 'the record key'
-                      : 'JSON path (e.g. events[].name)'
-                }
-                aria-label={`Field for condition ${index + 1}`}
-                disabled={conditionTarget(condition) === 'key'}
-                spellCheck={false}
-                autoComplete="off"
-                className="h-8 w-56 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50"
-              />
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className={cn('h-8 w-8 shrink-0 p-0', conditionTarget(condition) !== 'value' && 'invisible')}
-                onClick={() => onPickField(index)}
-                title="Browse sampled messages and pick a field"
-                aria-label={`Choose field for condition ${index + 1}`}
-              >
-                <ListTree className="h-3.5 w-3.5" />
-              </Button>
+              {/* The key is a single value with no name to give, so it gets no
+                  field box at all — a disabled one only invited typing the key
+                  into the wrong place. */}
+              {conditionTarget(condition) !== 'key' && (
+                <>
+                  <input
+                    value={condition.field}
+                    onChange={(event) => update(index, { field: event.target.value })}
+                    placeholder={
+                      conditionTarget(condition) === 'header' ? 'header name' : 'JSON path (e.g. events[].name)'
+                    }
+                    aria-label={`Field for condition ${index + 1}`}
+                    spellCheck={false}
+                    autoComplete="off"
+                    className="h-8 min-w-0 flex-1 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50"
+                  />
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className={cn(
+                      'h-8 w-8 shrink-0 p-0',
+                      conditionTarget(condition) !== 'value' && 'invisible'
+                    )}
+                    onClick={() => onPickField(index)}
+                    title="Browse sampled messages and pick a field"
+                    aria-label={`Choose field for condition ${index + 1}`}
+                  >
+                    <ListTree className="h-3.5 w-3.5" />
+                  </Button>
+                </>
+              )}
               <Select value={condition.op} onValueChange={(value) => update(index, { op: value as KafkaMatchOp })}>
-                <SelectTrigger className="h-8 w-32 font-mono text-xs" aria-label={`Match operator for condition ${index + 1}`}>
+                <SelectTrigger
+                  className="h-8 w-28 shrink-0 font-mono text-xs"
+                  aria-label={`Match operator for condition ${index + 1}`}
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -149,12 +155,22 @@ export function KafkaFilterDialog({
               <input
                 value={takesValue(condition.op) ? condition.value : ''}
                 onChange={(event) => update(index, { value: event.target.value })}
-                placeholder={takesValue(condition.op) ? 'compared value' : 'not used'}
+                placeholder={
+                  !takesValue(condition.op)
+                    ? 'not used'
+                    : conditionTarget(condition) === 'key'
+                      ? 'key to match'
+                      : 'value to match'
+                }
                 aria-label={`Expected value for condition ${index + 1}`}
                 disabled={!takesValue(condition.op)}
                 spellCheck={false}
                 autoComplete="off"
-                className="h-8 w-44 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+                className={cn(
+                  'h-8 min-w-0 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50',
+                  // With no field box on the row, the key's value takes the space it left.
+                  conditionTarget(condition) === 'key' ? 'flex-1' : 'w-44 shrink-0'
+                )}
               />
               <Button
                 type="button"

--- a/frontend/src/components/kafka/KafkaFilterDialog.tsx
+++ b/frontend/src/components/kafka/KafkaFilterDialog.tsx
@@ -3,7 +3,8 @@ import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
-import type { KafkaMatchCondition, KafkaMatchMode, KafkaMatchOp } from '@/stores/kafka'
+import { conditionTarget } from '@/stores/kafka'
+import type { KafkaMatchCondition, KafkaMatchMode, KafkaMatchOp, KafkaMatchTarget } from '@/stores/kafka'
 
 interface KafkaFilterDialogProps {
   open: boolean
@@ -17,6 +18,10 @@ interface KafkaFilterDialogProps {
 }
 
 export const emptyCondition: KafkaMatchCondition = { field: '', value: '', op: 'eq' }
+
+// Only equals and contains compare against typed text; presence ops read the
+// field alone.
+const takesValue = (op: KafkaMatchOp): boolean => op === 'eq' || op === 'contains'
 
 export function KafkaFilterDialog({
   open,
@@ -39,8 +44,8 @@ export function KafkaFilterDialog({
         <DialogHeader>
           <DialogTitle className="font-mono text-sm">Message filters</DialogTitle>
           <DialogDescription className="font-mono text-xs">
-            Each condition tests one JSON path in the message value. They apply both to the loaded messages and to a
-            topic scan.
+            Each condition tests the record key, one of its headers, or a JSON path in its value. They apply both to
+            the loaded messages and to a topic scan.
           </DialogDescription>
         </DialogHeader>
 
@@ -71,20 +76,51 @@ export function KafkaFilterDialog({
               <span className="w-8 shrink-0 font-mono text-[11px] text-muted-foreground">
                 {index === 0 ? '' : mode === 'or' ? 'or' : 'and'}
               </span>
+              <Select
+                value={conditionTarget(condition)}
+                onValueChange={(value) => update(index, { target: value as KafkaMatchTarget })}
+              >
+                <SelectTrigger
+                  className="h-8 w-24 shrink-0 font-mono text-xs"
+                  aria-label={`Where condition ${index + 1} looks`}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="value" className="font-mono text-xs">
+                    value
+                  </SelectItem>
+                  <SelectItem value="key" className="font-mono text-xs">
+                    key
+                  </SelectItem>
+                  <SelectItem value="header" className="font-mono text-xs">
+                    header
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              {/* The key is a single value with no name to give, so the field
+                  box has nothing to hold for it. */}
               <input
-                value={condition.field}
+                value={conditionTarget(condition) === 'key' ? '' : condition.field}
                 onChange={(event) => update(index, { field: event.target.value })}
-                placeholder="JSON path (e.g. events[].name)"
-                aria-label={`JSON field path for condition ${index + 1}`}
+                placeholder={
+                  conditionTarget(condition) === 'header'
+                    ? 'header name'
+                    : conditionTarget(condition) === 'key'
+                      ? 'the record key'
+                      : 'JSON path (e.g. events[].name)'
+                }
+                aria-label={`Field for condition ${index + 1}`}
+                disabled={conditionTarget(condition) === 'key'}
                 spellCheck={false}
                 autoComplete="off"
-                className="h-8 w-56 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50"
+                className="h-8 w-56 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50"
               />
               <Button
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-8 w-8 shrink-0 p-0"
+                className={cn('h-8 w-8 shrink-0 p-0', conditionTarget(condition) !== 'value' && 'invisible')}
                 onClick={() => onPickField(index)}
                 title="Browse sampled messages and pick a field"
                 aria-label={`Choose field for condition ${index + 1}`}
@@ -99,20 +135,23 @@ export function KafkaFilterDialog({
                   <SelectItem value="eq" className="font-mono text-xs">
                     equals
                   </SelectItem>
+                  <SelectItem value="contains" className="font-mono text-xs">
+                    contains
+                  </SelectItem>
                   <SelectItem value="exists" className="font-mono text-xs">
-                    has field
+                    {conditionTarget(condition) === 'value' ? 'has field' : 'is set'}
                   </SelectItem>
                   <SelectItem value="missing" className="font-mono text-xs">
-                    no field
+                    {conditionTarget(condition) === 'value' ? 'no field' : 'is unset'}
                   </SelectItem>
                 </SelectContent>
               </Select>
               <input
-                value={condition.op === 'eq' ? condition.value : ''}
+                value={takesValue(condition.op) ? condition.value : ''}
                 onChange={(event) => update(index, { value: event.target.value })}
-                placeholder={condition.op === 'eq' ? 'equals value' : 'not used'}
+                placeholder={takesValue(condition.op) ? 'compared value' : 'not used'}
                 aria-label={`Expected value for condition ${index + 1}`}
-                disabled={condition.op !== 'eq'}
+                disabled={!takesValue(condition.op)}
                 spellCheck={false}
                 autoComplete="off"
                 className="h-8 w-44 rounded-sm border border-border bg-background px-2 font-mono text-xs outline-none placeholder:text-muted-foreground focus:border-orange-500/50 disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/src/components/kafka/KafkaMessageBrowser.tsx
+++ b/frontend/src/components/kafka/KafkaMessageBrowser.tsx
@@ -21,6 +21,7 @@ import { FloatingMenu, FloatingMenuItem, FloatingMenuLabel, FloatingMenuSeparato
 import { extractMessageField, linkSourceLabel, linkSummary, linkTargetLabel } from '@/lib/links'
 import { cn } from '@/lib/utils'
 import {
+  activeConditions,
   filterLoadedMessages,
   MAX_SCAN_MATCHES,
   type KafkaDirection,
@@ -221,12 +222,21 @@ export function KafkaMessageBrowser({
     }))
   }, [linkPicker, links, reverseLinks, allConnectionLinks, connectionName, onOpenLink, onOpenReverse])
 
+  // Clearing means the query is gone, dialog included — the Filters badge
+  // counts what the dialog holds, so a leftover draft read as a filter that was
+  // still on.
+  const resetDraft = (clear: () => void) => () => {
+    clear()
+    setConditions([{ ...emptyCondition }])
+    setMode('and')
+  }
+
   const openMenu = (event: MouseEvent, message: KafkaMessageRow) => {
     event.preventDefault()
     setMenu({ x: event.clientX, y: event.clientY, message })
   }
 
-  const readyConditions = conditions.filter((condition) => condition.field.trim() !== '')
+  const readyConditions = activeConditions(conditions)
   const canFilter = readyConditions.length > 0 && !searchActive && messages.length > 0
   const canSearch = readyConditions.length > 0 && !scanning
 
@@ -368,7 +378,13 @@ export function KafkaMessageBrowser({
           <span>
             Filtered {messages.length.toLocaleString()} loaded messages · {visibleMessages.length.toLocaleString()} matches
           </span>
-          <Button type="button" size="sm" variant="ghost" className="h-6 gap-1 px-1.5 font-mono text-[11px]" onClick={onClearFilter}>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="h-6 gap-1 px-1.5 font-mono text-[11px]"
+            onClick={resetDraft(onClearFilter)}
+          >
             <X className="h-3 w-3" />
             Clear filter
           </Button>
@@ -404,7 +420,13 @@ export function KafkaMessageBrowser({
               Cancel
             </Button>
           ) : (
-            <Button type="button" size="sm" variant="ghost" className="h-6 gap-1 px-1.5 font-mono text-[11px]" onClick={onClearSearch}>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-6 gap-1 px-1.5 font-mono text-[11px]"
+              onClick={resetDraft(onClearSearch)}
+            >
               <X className="h-3 w-3" />
               Clear search
             </Button>

--- a/frontend/src/components/links/ConnectionLinksButton.tsx
+++ b/frontend/src/components/links/ConnectionLinksButton.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { LinkPickerDialog } from '@/components/links/LinkPickerDialog'
+import { connectionLinks, linkSummary } from '@/lib/links'
+import { useConnectionStore } from '@/stores/connections'
+import { useLinksStore } from '@/stores/links'
+
+interface ConnectionLinksButtonProps {
+  connId: string
+}
+
+/**
+ * Everything this connection is wired to, listed once at the connection level.
+ *
+ * It used to hang off the bottom of every object's own link menu, which put a
+ * list about the whole server in front of someone asking about one key: most of
+ * it could not be followed from there, and it buried the one or two links that
+ * could. Here it is reference material sitting where the rest of the
+ * connection-wide facts are, and an object's menu is only about that object.
+ */
+export function ConnectionLinksButton({ connId }: ConnectionLinksButtonProps) {
+  const links = useLinksStore((state) => state.links)
+  const fetchLinks = useLinksStore((state) => state.fetch)
+  const connections = useConnectionStore((state) => state.connections)
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    void fetchLinks().catch(() => undefined)
+  }, [fetchLinks])
+
+  const connectionName = (id: string) => connections.find((item) => item.id === id)?.name ?? id
+  const items = useMemo(
+    () =>
+      connectionLinks(links, connId).map((link) => ({
+        id: link.id,
+        // Reference only: a link is followed from the value it starts at, and
+        // there is no value at the connection level to follow one with.
+        label: linkSummary(link, connectionName),
+        disabled: true,
+        onPick: () => undefined,
+      })),
+    // connectionName reads `connections`, which is the dependency that matters.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [links, connId, connections]
+  )
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="h-8 shrink-0 gap-1.5 font-mono text-[11px]"
+        onClick={() => setOpen(true)}
+        title="Every cross-source link on this connection"
+      >
+        <Link2 className="h-3.5 w-3.5" />
+        {items.length}
+      </Button>
+      <LinkPickerDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={`Links on ${connectionName(connId)}`}
+        items={items}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/postgres/RowCardDialog.tsx
+++ b/frontend/src/components/postgres/RowCardDialog.tsx
@@ -2,9 +2,17 @@ import { Copy } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { clipboardFailureMessage, writeClipboardText } from '@/lib/clipboard'
+import { availableStatements, buildRowStatement, type RowStatementKind } from '@/lib/rowSql'
 import { cn } from '@/lib/utils'
 import { useToastStore } from '@/stores/toast'
 import type { ColumnMeta, TableRow } from '@/types/api'
+
+const STATEMENT_LABELS: Record<RowStatementKind, string> = {
+  select: 'SELECT',
+  insert: 'INSERT',
+  update: 'UPDATE',
+  delete: 'DELETE',
+}
 
 interface RowCardDialogProps {
   open: boolean
@@ -31,6 +39,25 @@ export function RowCardDialog({ open, columns, row, title, onOpenChange }: RowCa
     if (!ok) {
       pushToast({ tone: 'error', title: 'Copy failed', message: clipboardFailureMessage() })
     }
+  }
+
+  const statements = row ? availableStatements(columns, row) : []
+  const keyless = statements.length > 0 && !statements.includes('delete')
+
+  const copyStatement = async (kind: RowStatementKind) => {
+    if (!row) {
+      return
+    }
+    const statement = buildRowStatement(kind, title, columns, row)
+    if (!statement) {
+      return
+    }
+    const ok = await writeClipboardText(statement)
+    pushToast(
+      ok
+        ? { tone: 'success', title: `${STATEMENT_LABELS[kind]} copied`, message: title }
+        : { tone: 'error', title: 'Copy failed', message: clipboardFailureMessage() }
+    )
   }
 
   return (
@@ -84,6 +111,30 @@ export function RowCardDialog({ open, columns, row, title, onOpenChange }: RowCa
             </tbody>
           </table>
         </div>
+
+        {row && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[10px] uppercase tracking-[0.14em] text-muted-foreground">Copy as</span>
+            {statements.map((kind) => (
+              <Button
+                key={kind}
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 px-3 font-mono text-[11px]"
+                onClick={() => void copyStatement(kind)}
+              >
+                {STATEMENT_LABELS[kind]}
+              </Button>
+            ))}
+            {keyless && (
+              <span className="text-[11px] text-muted-foreground">
+                UPDATE and DELETE need a primary key — without one a statement could match rows other than
+                this.
+              </span>
+            )}
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/components/redis/RenameKeyDialog.tsx
+++ b/frontend/src/components/redis/RenameKeyDialog.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+import { PenLine, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+interface RenameKeyDialogProps {
+  open: boolean
+  keyName: string
+  saving: boolean
+  onOpenChange: (open: boolean) => void
+  onConfirm: (name: string) => Promise<void> | void
+}
+
+export function RenameKeyDialog({ open, keyName, saving, onOpenChange, onConfirm }: RenameKeyDialogProps) {
+  const [name, setName] = useState(keyName)
+
+  useEffect(() => {
+    if (open) {
+      setName(keyName)
+    }
+  }, [keyName, open])
+
+  const trimmed = name.trim()
+  const unchanged = trimmed === keyName
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!trimmed || unchanged || saving) {
+      return
+    }
+    await onConfirm(trimmed)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xl">
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-9 w-9 items-center justify-center rounded-md border border-amber-500/20 bg-amber-500/10 text-amber-500">
+                <PenLine className="h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <DialogTitle className="font-mono text-sm">Rename key</DialogTitle>
+                <DialogDescription className="truncate font-mono text-[11px] text-muted-foreground">
+                  {keyName}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <label className="block text-[10px] uppercase tracking-[0.14em] text-muted-foreground">
+              New name
+            </label>
+            <Input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="profile:1234"
+              className="font-mono"
+              aria-label="New key name"
+              autoFocus
+            />
+            <p className="text-[11px] text-muted-foreground">
+              A name already in use is refused rather than overwritten. The value and its TTL move with
+              the key.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="outline" size="sm" className="h-8 px-3">
+                <X className="h-3.5 w-3.5" />
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" size="sm" className="h-8 px-3" disabled={saving || !trimmed || unchanged}>
+              {saving ? 'Renaming…' : 'Rename'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/lib/jsonPaths.ts
+++ b/frontend/src/lib/jsonPaths.ts
@@ -200,6 +200,37 @@ export function leafEquals(leaf: unknown, want: string): boolean {
   }
 }
 
+// leafText renders a leaf the way leafEquals compares one, so a contains search
+// reads the same values an equals search does. Mirrors jsonLeafText in
+// messages.go; a composite leaf has no text form and matches nothing.
+export function leafText(leaf: unknown): string {
+  if (leaf === null) return 'null'
+  switch (typeof leaf) {
+    case 'boolean':
+    case 'number':
+      return String(leaf)
+    case 'string':
+      return leaf
+    default:
+      return ''
+  }
+}
+
+// matchFieldContains is matchField with substring comparison — finding a trace
+// id inside a longer url or message.
+export function matchFieldContains(rawValue: string, path: string, want: string): boolean {
+  if (path === '') return true
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(rawValue)
+  } catch {
+    return false
+  }
+  const segments = parsePath(path)
+  if (segments.length === 0) return false
+  return traverse(parsed, segments).some((leaf) => leafText(leaf).includes(want))
+}
+
 // matchField reports whether the raw JSON string has a leaf at the canonical
 // path equal to want. It mirrors the Go messageMatchesField predicate for the
 // shared fixture set: an empty path matches everything, invalid JSON never

--- a/frontend/src/lib/links.test.ts
+++ b/frontend/src/lib/links.test.ts
@@ -9,6 +9,7 @@ import {
   linkTouchesObject,
   memberRedisLinks,
   selectionRedisLinks,
+  valueRedisLinks,
 } from '@/lib/links'
 import type { LinkRecord } from '@/types/api'
 
@@ -130,6 +131,31 @@ describe('memberRedisLinks and keyLevelRedisLinks', () => {
 
   it('key-level links exclude every per-element mode', () => {
     expect(keyLevelRedisLinks(all, 'redis-1', 'profile:42').map((l) => l.id)).toEqual(['k'])
+  })
+})
+
+// Which links a click into the value may follow. Before these existed, a
+// string_value link could only be followed from the header menu, so a link just
+// created looked like one that had failed to save.
+describe('valueRedisLinks', () => {
+  const stringValue = link({ id: 'sv', source_extract: 'string_value' })
+  const valueField = link({ id: 'vf', source_extract: 'value_field', source_field: 'owner_id' })
+  const keyCapture = link({ id: 'kc', source_extract: 'key_capture' })
+  const member = link({ id: 'm', source_extract: 'member' })
+  const selection = link({ id: 's', source_extract: 'selection' })
+  const all = [stringValue, valueField, keyCapture, member, selection]
+
+  it('takes the links that read the value itself', () => {
+    expect(valueRedisLinks(all, 'redis-1', 'profile:42').map((l) => l.id)).toEqual(['sv', 'vf'])
+  })
+
+  it('leaves out key_capture, which reads the name rather than the value', () => {
+    expect(valueRedisLinks(all, 'redis-1', 'profile:42').map((l) => l.id)).not.toContain('kc')
+  })
+
+  it('ignores another connection and a key the pattern does not match', () => {
+    expect(valueRedisLinks(all, 'redis-2', 'profile:42')).toEqual([])
+    expect(valueRedisLinks(all, 'redis-1', 'session:42')).toEqual([])
   })
 })
 

--- a/frontend/src/lib/links.ts
+++ b/frontend/src/lib/links.ts
@@ -157,6 +157,18 @@ export function memberRedisLinks(links: LinkRecord[], connId: string, key: strin
   return links.filter((link) => isRedisSource(link, connId, key) && link.source_extract === 'member')
 }
 
+// valueRedisLinks — линки, читающие само значение ключа: string_value берёт его
+// целиком, value_field — поле внутри него. Именно они применимы к клику по
+// значению; key_capture сюда не входит — он читает имя ключа, а не то, на что
+// нажали.
+export function valueRedisLinks(links: LinkRecord[], connId: string, key: string): LinkRecord[] {
+  return links.filter(
+    (link) =>
+      isRedisSource(link, connId, key) &&
+      (link.source_extract === 'string_value' || link.source_extract === 'value_field')
+  )
+}
+
 // selectionRedisLinks — линки, применимые к точке, по которой кликнули. Линк с
 // заданным source_field сужен до одного хэш-поля (cookie_ids → c:*), линк без
 // поля работает в любом месте ключа. Поле undefined означает «кликнули не по

--- a/frontend/src/lib/objectDeepLink.test.ts
+++ b/frontend/src/lib/objectDeepLink.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { decodeObjectDeepLink, encodeObjectDeepLink } from '@/lib/objectDeepLink'
+
+describe('objectDeepLink', () => {
+  it('round-trips an object with no filters', () => {
+    const params = encodeObjectDeepLink({ object: 'public.users', objectType: 'table', filters: [] })
+    expect(params.toString()).toBe('object=public.users&type=table')
+    expect(decodeObjectDeepLink(params)).toEqual({
+      object: 'public.users',
+      objectType: 'table',
+      filters: [],
+    })
+  })
+
+  it('round-trips filters', () => {
+    const filters = [
+      { column: 'id', op: 'eq' as const, value: '123' },
+      { column: 'status', op: 'contains' as const, value: 'act' },
+    ]
+    const decoded = decodeObjectDeepLink(
+      encodeObjectDeepLink({ object: 'public.users', objectType: 'table', filters })
+    )
+    expect(decoded?.filters).toEqual(filters)
+  })
+
+  it('keeps a value that contains the separator', () => {
+    const filters = [{ column: 'created_at', op: 'gte' as const, value: '2026-08-19T10:30:00.500Z' }]
+    const decoded = decodeObjectDeepLink(
+      encodeObjectDeepLink({ object: 'events', objectType: 'table', filters })
+    )
+    expect(decoded?.filters).toEqual(filters)
+  })
+
+  it('carries a Redis key with colons and a Kafka topic', () => {
+    const key = decodeObjectDeepLink(
+      encodeObjectDeepLink({ object: 'profile:1234:meta', objectType: 'redis_hash', filters: [] })
+    )
+    expect(key).toEqual({ object: 'profile:1234:meta', objectType: 'redis_hash', filters: [] })
+
+    const topic = decodeObjectDeepLink(
+      encodeObjectDeepLink({ object: 'orders.v2', objectType: 'kafka_topic', filters: [] })
+    )
+    expect(topic?.objectType).toBe('kafka_topic')
+  })
+
+  it('has no link without an object', () => {
+    expect(decodeObjectDeepLink(new URLSearchParams(''))).toBeNull()
+    expect(decodeObjectDeepLink(new URLSearchParams('type=table'))).toBeNull()
+    expect(encodeObjectDeepLink(null).toString()).toBe('')
+  })
+
+  describe('a link from someone else', () => {
+    it('falls back to table for an unknown object type', () => {
+      expect(decodeObjectDeepLink(new URLSearchParams('object=x&type=nonsense'))?.objectType).toBe('table')
+    })
+
+    it('drops a filter with an operator it does not know', () => {
+      const decoded = decodeObjectDeepLink(
+        new URLSearchParams('object=x&type=table&filter=id.drop_table.1&filter=id.eq.2')
+      )
+      expect(decoded?.filters).toEqual([{ column: 'id', op: 'eq', value: '2' }])
+    })
+
+    it('drops a malformed filter', () => {
+      const decoded = decodeObjectDeepLink(
+        new URLSearchParams('object=x&type=table&filter=nodots&filter=.eq.1&filter=one.dot')
+      )
+      expect(decoded?.filters).toEqual([])
+    })
+  })
+
+  it('omits a filter whose column contains the separator rather than mangling it', () => {
+    const params = encodeObjectDeepLink({
+      object: 'x',
+      objectType: 'table',
+      filters: [
+        { column: 'odd.column', op: 'eq', value: '1' },
+        { column: 'id', op: 'eq', value: '2' },
+      ],
+    })
+    expect(params.getAll('filter')).toEqual(['id.eq.2'])
+  })
+})

--- a/frontend/src/lib/objectDeepLink.ts
+++ b/frontend/src/lib/objectDeepLink.ts
@@ -1,0 +1,117 @@
+import type { FilterExpr, ObjectType } from '@/types/api'
+
+/**
+ * The address bar as a shareable pointer at what is open.
+ *
+ * An investigation ends with "look at this" — a row, a key, a topic — and until
+ * now the only address Kizuna could produce was the connection it lived on. The
+ * open tab already carries everything the recipient needs, so it is mirrored
+ * into the query string: `?object=public.users&type=table&filter=id.eq.123`.
+ *
+ * Only object tabs are addressed. A SQL console holds a draft rather than a
+ * location, and Overview is one click from the connection itself — neither
+ * carries anything a link would have to say.
+ */
+
+const OBJECT_PARAM = 'object'
+const TYPE_PARAM = 'type'
+const FILTER_PARAM = 'filter'
+
+const OBJECT_TYPES: ObjectType[] = [
+  'table',
+  'view',
+  'index',
+  'namespace',
+  'redis_string',
+  'redis_hash',
+  'redis_list',
+  'redis_set',
+  'redis_zset',
+  'redis_stream',
+  'redis_json',
+  'kafka_topic',
+  'kafka_partition',
+  'kafka_consumer_group',
+]
+
+const FILTER_OPS: FilterExpr['op'][] = [
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'like',
+  'contains',
+  'is_null',
+  'is_not_null',
+]
+
+export interface ObjectDeepLink {
+  object: string
+  objectType: ObjectType
+  filters: FilterExpr[]
+}
+
+// column.op.value, the shape PostgREST made familiar. Only the first two dots
+// separate, so a value may contain as many as it likes — a timestamp, a
+// hostname, a decimal. A column name containing a dot is the one case this
+// cannot express; such a filter is dropped from the link rather than mangling
+// the rest of it.
+function encodeFilter(filter: FilterExpr): string {
+  return `${filter.column}.${filter.op}.${filter.value}`
+}
+
+function decodeFilter(raw: string): FilterExpr | null {
+  const firstDot = raw.indexOf('.')
+  if (firstDot <= 0) return null
+  const secondDot = raw.indexOf('.', firstDot + 1)
+  if (secondDot < 0) return null
+
+  const column = raw.slice(0, firstDot)
+  const op = raw.slice(firstDot + 1, secondDot)
+  const value = raw.slice(secondDot + 1)
+
+  if (!FILTER_OPS.includes(op as FilterExpr['op'])) return null
+  return { column, op: op as FilterExpr['op'], value }
+}
+
+/** Builds the query string for a tab. Returns empty params for no link. */
+export function encodeObjectDeepLink(link: ObjectDeepLink | null): URLSearchParams {
+  const params = new URLSearchParams()
+  if (!link || !link.object) {
+    return params
+  }
+  params.set(OBJECT_PARAM, link.object)
+  params.set(TYPE_PARAM, link.objectType)
+  link.filters.forEach((filter) => {
+    if (!filter.column.includes('.')) {
+      params.append(FILTER_PARAM, encodeFilter(filter))
+    }
+  })
+  return params
+}
+
+/**
+ * Reads a link out of the query string, or null when there is none.
+ *
+ * Everything here arrives from someone else's clipboard, so an unknown object
+ * type or a malformed filter is dropped rather than trusted: the worst outcome
+ * of a bad link should be the wrong tab, never a broken screen.
+ */
+export function decodeObjectDeepLink(params: URLSearchParams): ObjectDeepLink | null {
+  const object = params.get(OBJECT_PARAM)
+  if (!object) {
+    return null
+  }
+
+  const rawType = params.get(TYPE_PARAM) ?? 'table'
+  const objectType = OBJECT_TYPES.includes(rawType as ObjectType) ? (rawType as ObjectType) : 'table'
+
+  const filters = params
+    .getAll(FILTER_PARAM)
+    .map(decodeFilter)
+    .filter((filter): filter is FilterExpr => filter !== null)
+
+  return { object, objectType, filters }
+}

--- a/frontend/src/lib/rowSql.test.ts
+++ b/frontend/src/lib/rowSql.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest'
+import {
+  availableStatements,
+  buildRowStatement,
+  completePrimaryKey,
+  quoteQualifiedName,
+  sqlLiteral,
+} from '@/lib/rowSql'
+import type { ColumnMeta } from '@/types/api'
+
+function column(name: string, overrides: Partial<ColumnMeta> = {}): ColumnMeta {
+  return {
+    name,
+    data_type: 'text',
+    nullable: true,
+    default: null,
+    is_pk: false,
+    is_fk: false,
+    fk_table: '',
+    fk_column: '',
+    ...overrides,
+  }
+}
+
+const keyed = [column('id', { data_type: 'int4', is_pk: true }), column('name'), column('note')]
+const row = { id: 42, name: "O'Brien", note: null }
+
+describe('identifiers and literals', () => {
+  it('quotes both halves of a qualified name', () => {
+    expect(quoteQualifiedName('public.users')).toBe('"public"."users"')
+    expect(quoteQualifiedName('users')).toBe('"users"')
+    expect(quoteQualifiedName('public.order.items')).toBe('"public"."order.items"')
+  })
+
+  it('survives a quote inside an identifier', () => {
+    expect(quoteQualifiedName('we"ird')).toBe('"we""ird"')
+  })
+
+  it('escapes a quote inside a string rather than ending the literal', () => {
+    expect(sqlLiteral("O'Brien")).toBe("'O''Brien'")
+    expect(sqlLiteral("'; DROP TABLE users; --")).toBe("'''; DROP TABLE users; --'")
+  })
+
+  it('writes the other types the way Postgres reads them', () => {
+    expect(sqlLiteral(null)).toBe('NULL')
+    expect(sqlLiteral(undefined)).toBe('NULL')
+    expect(sqlLiteral(42)).toBe('42')
+    expect(sqlLiteral(-1.5)).toBe('-1.5')
+    expect(sqlLiteral(true)).toBe('TRUE')
+    expect(sqlLiteral(false)).toBe('FALSE')
+    expect(sqlLiteral({ a: 1 })).toBe(`'{"a":1}'`)
+    expect(sqlLiteral(['x', "y'z"])).toBe(`'["x","y''z"]'`)
+  })
+})
+
+describe('with a primary key', () => {
+  it('offers every statement', () => {
+    expect(availableStatements(keyed, row)).toEqual(['select', 'insert', 'update', 'delete'])
+  })
+
+  it('selects on the key alone', () => {
+    expect(buildRowStatement('select', 'public.users', keyed, row)).toBe(
+      'SELECT *\nFROM "public"."users"\nWHERE "id" = 42;'
+    )
+  })
+
+  it('deletes on the key alone', () => {
+    expect(buildRowStatement('delete', 'public.users', keyed, row)).toBe(
+      'DELETE FROM "public"."users"\nWHERE "id" = 42;'
+    )
+  })
+
+  it('inserts every column it has', () => {
+    expect(buildRowStatement('insert', 'public.users', keyed, row)).toBe(
+      'INSERT INTO "public"."users" ("id", "name", "note")\nVALUES (42, \'O\'\'Brien\', NULL);'
+    )
+  })
+
+  it('updates the non-key columns and keys the WHERE', () => {
+    expect(buildRowStatement('update', 'public.users', keyed, row)).toBe(
+      'UPDATE "public"."users"\nSET "name" = \'O\'\'Brien\',\n    "note" = NULL\nWHERE "id" = 42;'
+    )
+  })
+
+  it('keys on every column of a composite key', () => {
+    const columns = [
+      column('tenant', { is_pk: true }),
+      column('id', { is_pk: true }),
+      column('name'),
+    ]
+    expect(buildRowStatement('delete', 'orders', columns, { tenant: 'acme', id: 7, name: 'x' })).toBe(
+      'DELETE FROM "orders"\nWHERE "tenant" = \'acme\'\n  AND "id" = 7;'
+    )
+  })
+})
+
+describe('without a usable primary key', () => {
+  const unkeyed = [column('name'), column('note')]
+
+  it('refuses to write UPDATE or DELETE', () => {
+    expect(buildRowStatement('delete', 'logs', unkeyed, { name: 'a', note: 'b' })).toBeNull()
+    expect(buildRowStatement('update', 'logs', unkeyed, { name: 'a', note: 'b' })).toBeNull()
+    expect(availableStatements(unkeyed, { name: 'a' })).toEqual(['select', 'insert'])
+  })
+
+  it('counts a key whose value is missing as no key at all', () => {
+    const columns = [column('id', { is_pk: true }), column('name')]
+    expect(completePrimaryKey(columns, { id: null, name: 'x' })).toBeNull()
+    expect(buildRowStatement('delete', 'users', columns, { id: null, name: 'x' })).toBeNull()
+  })
+
+  it('needs every column of a composite key present', () => {
+    const columns = [column('tenant', { is_pk: true }), column('id', { is_pk: true })]
+    expect(completePrimaryKey(columns, { tenant: 'acme', id: null })).toBeNull()
+  })
+
+  it('still selects, matching on all columns with NULL handled', () => {
+    expect(buildRowStatement('select', 'logs', unkeyed, { name: 'a', note: null })).toBe(
+      'SELECT *\nFROM "logs"\nWHERE "name" = \'a\'\n  AND "note" IS NULL;'
+    )
+  })
+})
+
+describe('a row the grid only partly loaded', () => {
+  it('never claims a column the row does not carry', () => {
+    const statement = buildRowStatement('insert', 'users', keyed, { id: 1 })
+    expect(statement).toBe('INSERT INTO "users" ("id")\nVALUES (1);')
+  })
+
+  it('has nothing to update when only the key is present', () => {
+    expect(buildRowStatement('update', 'users', keyed, { id: 1 })).toBeNull()
+  })
+})

--- a/frontend/src/lib/rowSql.ts
+++ b/frontend/src/lib/rowSql.ts
@@ -1,0 +1,134 @@
+import type { ColumnMeta, TableRow } from '@/types/api'
+
+/**
+ * Statements for one row, to paste into a console, a ticket or a runbook.
+ *
+ * Editing a row in the grid changes it and leaves nothing behind; what gets
+ * pasted into an incident channel or a migration is the statement. So the
+ * statement is what this produces.
+ *
+ * The safety rule is UPDATE and DELETE: both are generated only against a
+ * complete primary key. A statement that says WHERE over ordinary columns looks
+ * just as precise and can match rows nobody looked at, which is the one mistake
+ * this feature could hand someone.
+ */
+
+export type RowStatementKind = 'select' | 'insert' | 'update' | 'delete'
+
+// Postgres identifier: always double-quoted, so a name that is a keyword, is
+// mixed case, or contains punctuation survives. A quote inside a name doubles.
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`
+}
+
+// "public.users" is two identifiers, not one. A dotted name is split on the
+// first dot only — a schema cannot contain one, a table can.
+export function quoteQualifiedName(object: string): string {
+  const dot = object.indexOf('.')
+  if (dot <= 0) {
+    return quoteIdent(object)
+  }
+  return `${quoteIdent(object.slice(0, dot))}.${quoteIdent(object.slice(dot + 1))}`
+}
+
+/**
+ * A value as a SQL literal.
+ *
+ * Strings are single-quoted with doubled quotes inside, which is what makes the
+ * output safe to paste. jsonb and arrays arrive as objects and are written as
+ * their JSON text — Postgres casts the literal on the way into a typed column.
+ * Numbers and booleans are written bare so they do not need one.
+ */
+export function sqlLiteral(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'NULL'
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : `'${value}'`
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'TRUE' : 'FALSE'
+  }
+  const text = typeof value === 'object' ? JSON.stringify(value) : String(value)
+  return `'${text.replace(/'/g, "''")}'`
+}
+
+function predicate(column: string, value: unknown): string {
+  if (value === null || value === undefined) {
+    return `${quoteIdent(column)} IS NULL`
+  }
+  return `${quoteIdent(column)} = ${sqlLiteral(value)}`
+}
+
+/**
+ * The primary key columns, but only when the row carries a value for every one
+ * of them. A partial key identifies nothing, so it counts as no key at all.
+ */
+export function completePrimaryKey(columns: ColumnMeta[], row: TableRow): ColumnMeta[] | null {
+  const pk = columns.filter((column) => column.is_pk)
+  if (pk.length === 0) {
+    return null
+  }
+  const complete = pk.every((column) => row[column.name] !== null && row[column.name] !== undefined)
+  return complete ? pk : null
+}
+
+/** Which statements can be written for this row. */
+export function availableStatements(columns: ColumnMeta[], row: TableRow): RowStatementKind[] {
+  return completePrimaryKey(columns, row) !== null
+    ? ['select', 'insert', 'update', 'delete']
+    : ['select', 'insert']
+}
+
+/**
+ * Builds one statement, or null when this row cannot support it.
+ *
+ * Without a primary key SELECT still works — it matches on every column, which
+ * is imprecise but harmless — while UPDATE and DELETE are refused outright.
+ */
+export function buildRowStatement(
+  kind: RowStatementKind,
+  object: string,
+  columns: ColumnMeta[],
+  row: TableRow
+): string | null {
+  const table = quoteQualifiedName(object)
+  const pk = completePrimaryKey(columns, row)
+
+  if ((kind === 'update' || kind === 'delete') && pk === null) {
+    return null
+  }
+
+  // Only the columns the row actually carries; a projection the grid narrowed
+  // must not turn into a statement claiming values it never saw.
+  const present = columns.filter((column) => column.name in row)
+  if (present.length === 0) {
+    return null
+  }
+
+  const where = (pk ?? present).map((column) => predicate(column.name, row[column.name])).join('\n  AND ')
+
+  switch (kind) {
+    case 'select':
+      return `SELECT *\nFROM ${table}\nWHERE ${where};`
+    case 'delete':
+      return `DELETE FROM ${table}\nWHERE ${where};`
+    case 'insert': {
+      const names = present.map((column) => quoteIdent(column.name)).join(', ')
+      const values = present.map((column) => sqlLiteral(row[column.name])).join(', ')
+      return `INSERT INTO ${table} (${names})\nVALUES (${values});`
+    }
+    case 'update': {
+      // The key identifies the row; setting it again says nothing and would
+      // quietly move the row if the value were edited afterwards.
+      const keyNames = new Set((pk ?? []).map((column) => column.name))
+      const assignments = present
+        .filter((column) => !keyNames.has(column.name))
+        .map((column) => `${quoteIdent(column.name)} = ${sqlLiteral(row[column.name])}`)
+      if (assignments.length === 0) {
+        return null
+      }
+      return `UPDATE ${table}\nSET ${assignments.join(',\n    ')}\nWHERE ${where};`
+    }
+  }
+}

--- a/frontend/src/pages/DataViewPage.tsx
+++ b/frontend/src/pages/DataViewPage.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import { useEffect, useRef } from 'react'
+import { useParams, useSearchParams } from 'react-router-dom'
 import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 import { Sidebar } from '@/components/Sidebar'
 import { TabBar } from '@/components/TabBar'
@@ -19,6 +19,8 @@ import { KafkaTopicView } from '@/components/kafka/KafkaTopicView'
 import { isRedisObjectType } from '@/lib/objectTypes'
 import { isConnectionHealthStale, useConnectionHealthStore } from '@/stores/connectionHealth'
 import { Button } from '@/components/ui/button'
+import { decodeObjectDeepLink, encodeObjectDeepLink } from '@/lib/objectDeepLink'
+import { useDataStore } from '@/stores/data'
 
 export default function DataViewPage() {
   const { id } = useParams<{ id: string }>()
@@ -44,9 +46,54 @@ export default function DataViewPage() {
     connectionTabs[connectionTabs.length - 1] ??
     null
 
+  const [searchParams, setSearchParams] = useSearchParams()
+  const openLinkedTab = useWorkspaceStore((state) => state.openLinkedTab)
+  const activeFilters = useDataStore((state) =>
+    activeTab ? state.tabs[activeTab.id]?.opts.filters : undefined
+  )
+  // The last query string this page and the URL agreed on. Anything else in the
+  // address bar came from outside — first load, a pasted link, browser Back —
+  // and has to be opened rather than overwritten.
+  const syncedQueryRef = useRef<string | null>(null)
+
   useEffect(() => {
     hydrateHealth()
   }, [hydrateHealth])
+
+  // Both directions live in one effect so their order is fixed: an address that
+  // arrived from outside is always consumed before the open tab is mirrored
+  // back out. Split in two, the mirror would race the arrival on first paint and
+  // overwrite the incoming link with whatever tab was restored from storage.
+  useEffect(() => {
+    if (!id) {
+      return
+    }
+
+    const incoming = searchParams.toString()
+    if (incoming !== syncedQueryRef.current) {
+      syncedQueryRef.current = incoming
+      const link = decodeObjectDeepLink(searchParams)
+      if (link) {
+        openLinkedTab(id, link.object, link.objectType, link.filters)
+        return
+      }
+    }
+
+    const outgoing = encodeObjectDeepLink(
+      activeTab && activeTab.kind === 'object'
+        ? {
+            object: activeTab.object,
+            objectType: activeTab.objectType,
+            filters: activeFilters ?? activeTab.initialFilters ?? [],
+          }
+        : null
+    ).toString()
+
+    if (outgoing !== incoming) {
+      syncedQueryRef.current = outgoing
+      setSearchParams(outgoing, { replace: true })
+    }
+  }, [activeFilters, activeTab, id, openLinkedTab, searchParams, setSearchParams])
 
   // Keep the global activeTabId in sync with the resolved tab so TabBar (which
   // reads activeTabId) highlights the correct tab after a connection switch.

--- a/frontend/src/stores/kafka.network.test.ts
+++ b/frontend/src/stores/kafka.network.test.ts
@@ -83,6 +83,43 @@ describe('Search topic — backend scan', () => {
     expect(calledUrl).toContain('match_value')
   })
 
+  // A key condition carries no field, and a rule that demanded one dropped it
+  // before it ever reached a request — the filter simply did nothing.
+  it('a key condition is sent with no field of its own', async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(
+        jsonResponse({ columns: [], rows: [], total: 0, has_more: false, meta: { scanned: 5, matched: 0 } })
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await useKafkaStore
+      .getState()
+      .searchTopic('c1', 'topic', 'tab-key', [{ field: '', value: 'user-42', op: 'eq', target: 'key' }])
+
+    const calledUrl = decodeURIComponent(String(fetchMock.mock.calls[0][0]))
+    expect(calledUrl).toContain('"match_target","op":"eq","value":"key"')
+    expect(calledUrl).toContain('"match_value","op":"eq","value":"user-42"')
+    expect(calledUrl).not.toContain('match_field')
+  })
+
+  // Switching a condition from the payload to the key leaves the old path in
+  // the box; it must not ride along as a field the key does not have.
+  it('drops a leftover path when the condition moved to the key', async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve(
+        jsonResponse({ columns: [], rows: [], total: 0, has_more: false, meta: { scanned: 1, matched: 0 } })
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock as unknown as typeof fetch)
+
+    await useKafkaStore
+      .getState()
+      .searchTopic('c1', 'topic', 'tab-stale', [{ field: 'events[].name', value: 'user-42', op: 'eq', target: 'key' }])
+
+    expect(decodeURIComponent(String(fetchMock.mock.calls[0][0]))).not.toContain('events[].name')
+  })
+
   it('scanMore continues from the prior cursor and accumulates scanned + matches', async () => {
     const fetchMock = vi
       .fn()

--- a/frontend/src/stores/kafka.ts
+++ b/frontend/src/stores/kafka.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { fetchWithTimeout, RequestAbortedError, throwOnApiError } from '@/lib/http'
-import { fieldPresence, matchField } from '@/lib/jsonPaths'
+import { fieldPresence, matchField, matchFieldContains } from '@/lib/jsonPaths'
 import type { ColumnMeta, KafkaProduceRequest, KafkaProduceResult, ObjectItem } from '@/types/api'
 
 export interface KafkaMessageRow {
@@ -86,14 +86,28 @@ interface KafkaTopicTabState {
 // What the searched field must satisfy. 'eq' is the original value search;
 // 'exists'/'missing' answer "does this field occur at all", which is the only
 // way to look for a field whose values are not known yet.
-export type KafkaMatchOp = 'eq' | 'exists' | 'missing'
+export type KafkaMatchOp = 'eq' | 'contains' | 'exists' | 'missing'
 
-// One condition of a content search: a JSON path, what it must satisfy, and
-// the value to compare when the op is 'eq'.
+// Which part of the record a condition reads. The payload is the default; a key
+// or header holds the correlation id, tenant or event type, and is readable even
+// when the payload is binary.
+export type KafkaMatchTarget = 'value' | 'key' | 'header'
+
+// One condition of a content search: where to look, what to satisfy, and the
+// value to compare when the op is 'eq' or 'contains'. `field` is a JSON path in
+// the payload or a header name; a key condition has none.
 export interface KafkaMatchCondition {
   field: string
   value: string
   op: KafkaMatchOp
+  // Absent means the payload, which is what the backend assumes for a request
+  // that carries no match_target — so an old condition keeps its meaning and
+  // produces the same request it always did.
+  target?: KafkaMatchTarget
+}
+
+export function conditionTarget(condition: KafkaMatchCondition): KafkaMatchTarget {
+  return condition.target ?? 'value'
 }
 
 // How a set of conditions combines. 'and' narrows (every condition must hold),
@@ -106,9 +120,10 @@ interface KafkaSearch {
 }
 
 // A condition with no field is incomplete, not a wildcard: an empty row in the
-// filter dialog must never widen a search.
+// filter dialog must never widen a search. The key is the exception — it is a
+// single value with no name to give, so a key condition is complete as it is.
 export function activeConditions(conditions: KafkaMatchCondition[]): KafkaMatchCondition[] {
-  return conditions.filter((condition) => condition.field.trim() !== '')
+  return conditions.filter((condition) => conditionTarget(condition) === 'key' || condition.field.trim() !== '')
 }
 
 // Which end of the log a browse starts from. 'newest' anchors at the end and
@@ -258,10 +273,41 @@ function ensureState(tabs: Record<string, KafkaTopicTabState>, tabId: string): K
 // the raw `messages`/cursor state.
 function conditionMatches(row: KafkaMessageRow, condition: KafkaMatchCondition): boolean {
   const path = condition.field.trim()
+
+  // Key and header conditions read strings the broker delivers beside the
+  // payload, so they hold for a record whose body never parses as JSON. Mirrors
+  // messageMatchesFilter in messages.go, down to a keyless record counting as
+  // absent rather than empty.
+  const target = conditionTarget(condition)
+  if (target === 'key') {
+    return stringMatches(row.key, Boolean(row.key), condition.value, condition.op)
+  }
+  if (target === 'header') {
+    if (path === '') return true
+    const present = row.headers !== undefined && path in row.headers
+    return stringMatches(row.headers?.[path] ?? '', present, condition.value, condition.op)
+  }
+
   if (condition.op === 'exists' || condition.op === 'missing') {
     return fieldPresence(row.value, path, condition.op === 'exists')
   }
+  if (condition.op === 'contains') {
+    return matchFieldContains(row.value, path, condition.value)
+  }
   return matchField(row.value, path, condition.value)
+}
+
+function stringMatches(value: string, present: boolean, want: string, op: KafkaMatchOp): boolean {
+  switch (op) {
+    case 'exists':
+      return present
+    case 'missing':
+      return !present
+    case 'contains':
+      return present && value.includes(want)
+    default:
+      return present && value === want
+  }
 }
 
 // filterLoadedMessages narrows the rows already on screen — no network. It
@@ -401,6 +447,11 @@ async function requestMessages(
       filters.push({ column: `match_field${suffix}`, op: 'eq', value: condition.field })
       filters.push({ column: `match_value${suffix}`, op: 'eq', value: condition.value })
       filters.push({ column: `match_op${suffix}`, op: 'eq', value: condition.op })
+      // Only sent when it says something: a payload condition is the default,
+      // and leaving it out keeps the request identical to what it was before.
+      if (condition.target !== undefined && condition.target !== 'value') {
+        filters.push({ column: `match_target${suffix}`, op: 'eq', value: condition.target })
+      }
     })
     filters.push({ column: 'match_mode', op: 'eq', value: search.mode })
   }

--- a/frontend/src/stores/kafka.ts
+++ b/frontend/src/stores/kafka.ts
@@ -444,7 +444,11 @@ async function requestMessages(
     // numbered; parseMatchQuery in messages.go reads both.
     activeConditions(search.conditions).forEach((condition, index) => {
       const suffix = index === 0 ? '' : `.${index}`
-      filters.push({ column: `match_field${suffix}`, op: 'eq', value: condition.field })
+      // A key condition has no field. Text left in the box from an earlier
+      // target would ride along and mean nothing.
+      if (conditionTarget(condition) !== 'key') {
+        filters.push({ column: `match_field${suffix}`, op: 'eq', value: condition.field })
+      }
       filters.push({ column: `match_value${suffix}`, op: 'eq', value: condition.value })
       filters.push({ column: `match_op${suffix}`, op: 'eq', value: condition.op })
       // Only sent when it says something: a payload condition is the default,

--- a/frontend/src/stores/kafkaKeyHeaderFilter.test.ts
+++ b/frontend/src/stores/kafkaKeyHeaderFilter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { activeConditions, filterLoadedMessages, type KafkaMessageRow } from '@/stores/kafka'
+
+// "Filter loaded" and "Search topic" must agree about what matches, so these
+// cases are the twins of TestMessageMatchesFilterOnKeyAndHeaders in
+// internal/connector/kafka/key_header_filter_test.go. A disagreement between the
+// two has been a real bug here before.
+function record(
+  offset: number,
+  fields: Partial<Pick<KafkaMessageRow, 'key' | 'value' | 'format' | 'headers'>>
+): KafkaMessageRow {
+  return {
+    partition: 0,
+    offset,
+    timestamp: '',
+    key: '',
+    value: '{}',
+    format: 'json',
+    ...fields,
+  }
+}
+
+const binary = record(1, {
+  key: 'user-42',
+  value: 'AQIDBA==',
+  format: 'binary',
+  headers: { 'trace-id': 'abc-123-def', source: 'checkout' },
+})
+const keyless = record(2, { key: '', value: '{}' })
+
+describe('filtering by key', () => {
+  it('matches an exact key even when the payload is binary', () => {
+    const matches = filterLoadedMessages([binary, keyless], [
+      { field: '', value: 'user-42', op: 'eq', target: 'key' },
+    ])
+    expect(matches.map((m) => m.offset)).toEqual([1])
+  })
+
+  it('does not match a prefix under equals', () => {
+    expect(
+      filterLoadedMessages([binary], [{ field: '', value: 'user-4', op: 'eq', target: 'key' }])
+    ).toEqual([])
+  })
+
+  it('matches a substring under contains', () => {
+    const matches = filterLoadedMessages([binary, keyless], [
+      { field: '', value: '-42', op: 'contains', target: 'key' },
+    ])
+    expect(matches.map((m) => m.offset)).toEqual([1])
+  })
+
+  it('separates a keyless record from an empty key', () => {
+    expect(
+      filterLoadedMessages([binary, keyless], [{ field: '', value: '', op: 'missing', target: 'key' }]).map(
+        (m) => m.offset
+      )
+    ).toEqual([2])
+    expect(
+      filterLoadedMessages([binary, keyless], [{ field: '', value: '', op: 'exists', target: 'key' }]).map(
+        (m) => m.offset
+      )
+    ).toEqual([1])
+  })
+
+  it('counts a key condition as complete without a field', () => {
+    expect(activeConditions([{ field: '', value: 'x', op: 'eq', target: 'key' }])).toHaveLength(1)
+    expect(activeConditions([{ field: '', value: 'x', op: 'eq', target: 'header' }])).toHaveLength(0)
+    expect(activeConditions([{ field: '', value: 'x', op: 'eq' }])).toHaveLength(0)
+  })
+})
+
+describe('filtering by header', () => {
+  it('matches a header value', () => {
+    const matches = filterLoadedMessages([binary, keyless], [
+      { field: 'source', value: 'checkout', op: 'eq', target: 'header' },
+    ])
+    expect(matches.map((m) => m.offset)).toEqual([1])
+  })
+
+  it('matches part of a header value', () => {
+    const matches = filterLoadedMessages([binary], [
+      { field: 'trace-id', value: '123', op: 'contains', target: 'header' },
+    ])
+    expect(matches).toHaveLength(1)
+  })
+
+  it('reports a header absent on a record carrying none', () => {
+    const matches = filterLoadedMessages([binary, keyless], [
+      { field: 'trace-id', value: '', op: 'exists', target: 'header' },
+    ])
+    expect(matches.map((m) => m.offset)).toEqual([1])
+  })
+
+  it('treats header names as case-sensitive, as Kafka does', () => {
+    expect(
+      filterLoadedMessages([binary], [{ field: 'Source', value: '', op: 'exists', target: 'header' }])
+    ).toEqual([])
+  })
+})
+
+describe('contains inside the payload', () => {
+  const doc = record(3, { value: '{"url":"https://example.test/checkout?trace=abc-123","attempts":42}' })
+
+  it('matches a substring of a string leaf', () => {
+    expect(
+      filterLoadedMessages([doc], [{ field: 'url', value: 'trace=abc-123', op: 'contains' }])
+    ).toHaveLength(1)
+  })
+
+  it('searches a number leaf as its rendered text', () => {
+    expect(filterLoadedMessages([doc], [{ field: 'attempts', value: '4', op: 'contains' }])).toHaveLength(1)
+  })
+
+  it('does not match an absent substring', () => {
+    expect(filterLoadedMessages([doc], [{ field: 'url', value: 'nope', op: 'contains' }])).toEqual([])
+  })
+})

--- a/frontend/src/stores/workspace.ts
+++ b/frontend/src/stores/workspace.ts
@@ -121,6 +121,7 @@ interface WorkspaceStore {
   setTreeConn: (pageConnId: string, viewConnId: string) => void
   rebindSqlTab: (tabId: string, connId: string) => void
   openTabWithFilter: (connId: string, object: string, filter: FilterExpr, objectType?: ObjectType) => void
+  openLinkedTab: (connId: string, object: string, objectType: ObjectType, filters: FilterExpr[]) => void
   clearObjectTabFilterState: (tabId: string) => void
   goBackFromTab: (tabId: string) => void
   openSqlTab: (connId: string) => void
@@ -721,6 +722,53 @@ export const useWorkspaceStore = create<WorkspaceStore>((set, get) => ({
         }
       }),
     }))
+  },
+
+  // Opening what a shared link points at. Unlike openTabWithFilter this records
+  // no navigation history: arriving from someone else's URL is not a step back
+  // from anywhere, and inventing a "from" tab would put a Back arrow on a trail
+  // this session never walked.
+  openLinkedTab: (connId: string, object: string, objectType: ObjectType, filters: FilterExpr[]) => {
+    const normalized = normalizeFilters(filters)
+    if (normalized.length === 0) {
+      get().openTab(connId, object, objectType)
+      return
+    }
+
+    const { tabs } = get()
+    const dataTabs = useDataStore.getState().tabs
+    const existing = tabs.find((tab) => {
+      if (tab.kind !== 'object' || tab.connId !== connId || tab.object !== object || tab.objectType !== objectType) {
+        return false
+      }
+      const activeFilters = dataTabs[tab.id]?.opts.filters ?? tab.initialFilters ?? []
+      return filtersEqual(activeFilters, normalized)
+    })
+    if (existing) {
+      set({ activeTabId: existing.id })
+      return
+    }
+
+    const id = buildFilteredTabID(connId, object, objectType, normalized)
+    const tab: ObjectTab = {
+      kind: 'object',
+      id,
+      connId,
+      object,
+      label: `${object} (filtered)`,
+      objectType,
+      initialFilters: normalized,
+      navigationTrail: [{ tabId: id, label: object, filterLabel: buildFilterLabel(normalized) }],
+    }
+
+    useDataStore.getState().setOpts(id, {
+      filters: normalized,
+      offset: 0,
+      order_by: '',
+      order_dir: 'asc',
+    })
+
+    set({ tabs: [...tabs, tab], activeTabId: id })
   },
 
   openTabWithFilter: (connId: string, object: string, filter: FilterExpr, objectType: ObjectType = 'table') => {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -6,7 +6,6 @@ export interface KafkaConfig {
   sasl_mechanism?: string
   tls_enabled?: boolean
   tls_ca_pem?: string
-  schema_registry_url?: string
 }
 export type PostgresSSLMode = 'disable' | 'prefer' | 'require' | 'verify-ca' | 'verify-full'
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -290,8 +290,9 @@ export interface FilterExpr {
 }
 
 export interface MutateOp {
-  // 'copy' duplicates a key under a new name; Redis only.
-  type: 'insert' | 'update' | 'delete' | 'copy'
+  // 'copy' duplicates a key under a new name and 'rename' moves it to one;
+  // both are Redis only.
+  type: 'insert' | 'update' | 'delete' | 'copy' | 'rename'
   schema: string
   object: string
   where?: Record<string, unknown>

--- a/internal/connector/kafka/kafka_test.go
+++ b/internal/connector/kafka/kafka_test.go
@@ -423,9 +423,9 @@ func TestParseMatchQueryMultipleConditions(t *testing.T) {
 		t.Fatalf("mode = %q, want or", query.mode)
 	}
 	want := []contentFilter{
-		{field: "user.id", value: "42", op: matchOpEquals},
-		{field: "event", value: "signup", op: matchOpEquals},
-		{field: "trace", op: matchOpMissing},
+		{field: "user.id", value: "42", op: matchOpEquals, target: matchTargetValue},
+		{field: "event", value: "signup", op: matchOpEquals, target: matchTargetValue},
+		{field: "trace", op: matchOpMissing, target: matchTargetValue},
 	}
 	if !reflect.DeepEqual(query.filters, want) {
 		t.Fatalf("filters = %+v, want %+v", query.filters, want)

--- a/internal/connector/kafka/key_header_filter_test.go
+++ b/internal/connector/kafka/key_header_filter_test.go
@@ -1,0 +1,169 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/zxchlorka/kizuna/internal/connector"
+)
+
+// A record whose payload is not JSON at all: the point of key and header
+// conditions is that they still work here, where a payload path cannot.
+func binaryRecord() map[string]any {
+	return map[string]any{
+		"key":     "user-42",
+		"value":   "AQIDBA==",
+		"format":  "binary",
+		"headers": map[string]string{"trace-id": "abc-123-def", "source": "checkout"},
+	}
+}
+
+func TestMessageMatchesFilterOnKeyAndHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter contentFilter
+		row    map[string]any
+		want   bool
+	}{
+		{
+			name:   "key equals",
+			filter: contentFilter{target: matchTargetKey, value: "user-42", op: matchOpEquals},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			name:   "key equals is exact",
+			filter: contentFilter{target: matchTargetKey, value: "user-4", op: matchOpEquals},
+			row:    binaryRecord(),
+			want:   false,
+		},
+		{
+			name:   "key contains",
+			filter: contentFilter{target: matchTargetKey, value: "-42", op: matchOpContains},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			name:   "key exists",
+			filter: contentFilter{target: matchTargetKey, op: matchOpExists},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			// A record produced without a key: absent, not empty.
+			name:   "key missing on a keyless record",
+			filter: contentFilter{target: matchTargetKey, op: matchOpMissing},
+			row:    map[string]any{"key": "", "value": "{}", "format": "json"},
+			want:   true,
+		},
+		{
+			name:   "key equals never matches a keyless record",
+			filter: contentFilter{target: matchTargetKey, value: "", op: matchOpEquals},
+			row:    map[string]any{"key": "", "value": "{}", "format": "json"},
+			want:   false,
+		},
+		{
+			name:   "header equals",
+			filter: contentFilter{target: matchTargetHeader, field: "source", value: "checkout", op: matchOpEquals},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			name:   "header contains",
+			filter: contentFilter{target: matchTargetHeader, field: "trace-id", value: "123", op: matchOpContains},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			name:   "header exists",
+			filter: contentFilter{target: matchTargetHeader, field: "trace-id", op: matchOpExists},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			name:   "header missing",
+			filter: contentFilter{target: matchTargetHeader, field: "tenant", op: matchOpMissing},
+			row:    binaryRecord(),
+			want:   true,
+		},
+		{
+			name:   "header on a record with no headers at all",
+			filter: contentFilter{target: matchTargetHeader, field: "trace-id", op: matchOpExists},
+			row:    map[string]any{"key": "k", "value": "{}", "format": "json"},
+			want:   false,
+		},
+		{
+			// Header names are case-sensitive in Kafka, and so is this.
+			name:   "header name case matters",
+			filter: contentFilter{target: matchTargetHeader, field: "Source", op: matchOpExists},
+			row:    binaryRecord(),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := messageMatchesFilter(tt.row, tt.filter); got != tt.want {
+				t.Fatalf("matched = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPayloadContainsOp(t *testing.T) {
+	t.Parallel()
+
+	row := map[string]any{
+		"value":  `{"url":"https://example.test/checkout?trace=abc-123","attempts":42}`,
+		"format": "json",
+	}
+
+	if !messageMatchesFilter(row, contentFilter{field: "url", value: "trace=abc-123", op: matchOpContains, target: matchTargetValue}) {
+		t.Error("substring of a string leaf should match")
+	}
+	if !messageMatchesFilter(row, contentFilter{field: "attempts", value: "4", op: matchOpContains, target: matchTargetValue}) {
+		t.Error("a number leaf should be searchable as its rendered text")
+	}
+	if messageMatchesFilter(row, contentFilter{field: "url", value: "not-there", op: matchOpContains, target: matchTargetValue}) {
+		t.Error("absent substring should not match")
+	}
+}
+
+func TestParseMatchQueryTargets(t *testing.T) {
+	t.Parallel()
+
+	query := parseMatchQuery([]connector.FilterExpr{
+		{Column: "match_target", Value: "key"},
+		{Column: "match_op", Value: "contains"},
+		{Column: "match_value", Value: "user-"},
+		{Column: "match_target.1", Value: "header"},
+		{Column: "match_field.1", Value: "trace-id"},
+		{Column: "match_value.1", Value: "abc"},
+	})
+
+	if len(query.filters) != 2 {
+		t.Fatalf("filters = %+v, want 2", query.filters)
+	}
+	// A key condition carries no field and must survive the drop that removes
+	// blank rows.
+	if query.filters[0].target != matchTargetKey || query.filters[0].op != matchOpContains {
+		t.Errorf("key condition = %+v", query.filters[0])
+	}
+	if query.filters[1].target != matchTargetHeader || query.filters[1].field != "trace-id" {
+		t.Errorf("header condition = %+v", query.filters[1])
+	}
+}
+
+func TestParseMatchQueryDropsBlankNonKeyConditions(t *testing.T) {
+	t.Parallel()
+
+	query := parseMatchQuery([]connector.FilterExpr{
+		{Column: "match_target", Value: "header"},
+		{Column: "match_value", Value: "orphan"},
+	})
+	if len(query.filters) != 0 {
+		t.Fatalf("a header condition with no name should be dropped, got %+v", query.filters)
+	}
+}

--- a/internal/connector/kafka/messages.go
+++ b/internal/connector/kafka/messages.go
@@ -1365,9 +1365,24 @@ func parseCursorOffsets(filters []connector.FilterExpr, direction readDirection)
 type matchOp string
 
 const (
-	matchOpEquals  matchOp = "eq"
-	matchOpExists  matchOp = "exists"
-	matchOpMissing matchOp = "missing"
+	matchOpEquals   matchOp = "eq"
+	matchOpContains matchOp = "contains"
+	matchOpExists   matchOp = "exists"
+	matchOpMissing  matchOp = "missing"
+)
+
+// matchTarget is the part of the record a condition reads.
+//
+// The payload is the default and was the only option: a condition names a JSON
+// path inside it. A key or a header is where correlation ids, tenants and event
+// types usually live, and looking there costs no JSON parsing at all — the
+// record carries both as plain strings whatever the payload turns out to be.
+type matchTarget string
+
+const (
+	matchTargetValue  matchTarget = "value"
+	matchTargetKey    matchTarget = "key"
+	matchTargetHeader matchTarget = "header"
 )
 
 // matchMode combines a multi-condition search. AND is the default because it is
@@ -1381,9 +1396,17 @@ const (
 
 // contentFilter is one field predicate of a content search.
 type contentFilter struct {
-	field string
-	value string
-	op    matchOp
+	field  string
+	value  string
+	op     matchOp
+	target matchTarget
+}
+
+// addressable reports whether the condition names something to look at. A
+// payload path or a header needs a field; the key is a single value and has
+// none, so a key condition is complete on its own.
+func (f contentFilter) addressable() bool {
+	return f.target == matchTargetKey || f.field != ""
 }
 
 // matchQuery is the whole content search: the conditions and how they combine.
@@ -1418,7 +1441,7 @@ func parseMatchQuery(filters []connector.FilterExpr) matchQuery {
 		if existing, ok := byIndex[index]; ok {
 			return existing
 		}
-		created := &contentFilter{op: matchOpEquals}
+		created := &contentFilter{op: matchOpEquals, target: matchTargetValue}
 		byIndex[index] = created
 		order = append(order, index)
 		return created
@@ -1445,8 +1468,19 @@ func parseMatchQuery(filters []connector.FilterExpr) matchQuery {
 				at(index).op = matchOpExists
 			case matchOpMissing:
 				at(index).op = matchOpMissing
+			case matchOpContains:
+				at(index).op = matchOpContains
 			case matchOpEquals:
 				at(index).op = matchOpEquals
+			}
+		case "match_target":
+			switch matchTarget(strings.ToLower(strings.TrimSpace(filter.Value))) {
+			case matchTargetKey:
+				at(index).target = matchTargetKey
+			case matchTargetHeader:
+				at(index).target = matchTargetHeader
+			case matchTargetValue:
+				at(index).target = matchTargetValue
 			}
 		}
 	}
@@ -1455,7 +1489,7 @@ func parseMatchQuery(filters []connector.FilterExpr) matchQuery {
 	// are combined by AND or OR, both commutative. First-seen order keeps the
 	// unnumbered condition first, where the caller put it.
 	for _, index := range order {
-		if byIndex[index].field != "" {
+		if byIndex[index].addressable() {
 			query.filters = append(query.filters, *byIndex[index])
 		}
 	}
@@ -1702,7 +1736,7 @@ func messageMatchesQuery(row map[string]any, query matchQuery) bool {
 		return true
 	}
 	for _, filter := range query.filters {
-		matched := messageMatchesField(row, filter.field, filter.value, filter.op)
+		matched := messageMatchesFilter(row, filter)
 		if query.mode == matchModeOr {
 			if matched {
 				return true
@@ -1714,6 +1748,63 @@ func messageMatchesQuery(row map[string]any, query matchQuery) bool {
 		}
 	}
 	return query.mode != matchModeOr
+}
+
+// messageMatchesFilter routes a condition to the part of the record it reads.
+//
+// Only the payload predicate needs the record to be JSON. A key or header is a
+// string the broker delivers alongside the payload, so those conditions hold
+// for a record whose body is protobuf, binary, or unparseable — which is much
+// of what a search by correlation id is for.
+func messageMatchesFilter(row map[string]any, filter contentFilter) bool {
+	switch filter.target {
+	case matchTargetKey:
+		key, present := recordKey(row)
+		return stringMatches(key, present, filter.value, filter.op)
+	case matchTargetHeader:
+		if filter.field == "" {
+			return true
+		}
+		value, present := recordHeader(row, filter.field)
+		return stringMatches(value, present, filter.value, filter.op)
+	default:
+		return messageMatchesField(row, filter.field, filter.value, filter.op)
+	}
+}
+
+// recordKey reports the record's key and whether it had one at all. A record
+// produced without a key — every message on a topic that does not partition by
+// one, and every tombstone — is absent rather than empty, so "missing" can tell
+// the two apart.
+func recordKey(row map[string]any) (string, bool) {
+	key, ok := row["key"].(string)
+	if !ok || key == "" {
+		return "", false
+	}
+	return key, true
+}
+
+func recordHeader(row map[string]any, name string) (string, bool) {
+	headers, ok := row["headers"].(map[string]string)
+	if !ok {
+		return "", false
+	}
+	value, present := headers[name]
+	return value, present
+}
+
+// stringMatches applies an op to a plain string that may not be there at all.
+func stringMatches(value string, present bool, want string, op matchOp) bool {
+	switch op {
+	case matchOpExists:
+		return present
+	case matchOpMissing:
+		return !present
+	case matchOpContains:
+		return present && strings.Contains(value, want)
+	default:
+		return present && value == want
+	}
 }
 
 // messageMatchesField reports whether a message contains a JSON leaf at the
@@ -1759,6 +1850,8 @@ func messageMatchesField(row map[string]any, field string, want string, op match
 		return jsonPathMatchesAnywhere(parsed, segments, anyLeaf)
 	case matchOpMissing:
 		return !jsonPathMatchesAnywhere(parsed, segments, anyLeaf)
+	case matchOpContains:
+		return jsonPathMatchesAnywhere(parsed, segments, containsLeaf(want))
 	default:
 		return jsonPathMatchesAnywhere(parsed, segments, equalsLeaf(want))
 	}
@@ -1773,6 +1866,12 @@ func anyLeaf(any) bool { return true }
 
 func equalsLeaf(want string) leafPredicate {
 	return func(leaf any) bool { return jsonLeafEquals(leaf, want) }
+}
+
+// containsLeaf matches a leaf whose rendered form carries want as a substring —
+// how a trace id is found inside a longer message or url.
+func containsLeaf(want string) leafPredicate {
+	return func(leaf any) bool { return strings.Contains(jsonLeafText(leaf), want) }
 }
 
 type jsonPathSegmentKind int
@@ -1924,6 +2023,24 @@ func jsonPathMatchesFrom(value any, segments []jsonPathSegment, leaf leafPredica
 
 // jsonLeafEquals compares a decoded JSON scalar to the entered string. Numbers
 // compare numerically so "123" matches 123; nested objects/arrays never match.
+// jsonLeafText renders a leaf the way jsonLeafEquals compares one, so that a
+// contains search reads the same values an equals search does. A composite —
+// object or array — has no text form here and yields "", matching nothing.
+func jsonLeafText(leaf any) string {
+	switch typed := leaf.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return strconv.FormatBool(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case string:
+		return typed
+	default:
+		return ""
+	}
+}
+
 func jsonLeafEquals(leaf any, want string) bool {
 	switch typed := leaf.(type) {
 	case nil:

--- a/internal/connector/redis/mutate.go
+++ b/internal/connector/redis/mutate.go
@@ -36,6 +36,16 @@ func (c *RedisConnector) Mutate(ctx context.Context, op connector.MutateOp) (*co
 		}
 	}
 
+	if op.Type == "rename" {
+		destination, _ := op.Data["destination"].(string)
+		destination = strings.TrimSpace(destination)
+		if err := c.renameKeyTo(ctx, op.Object, destination); err != nil {
+			return nil, err
+		}
+		c.invalidateKeyMeta(op.Object, destination)
+		return &connector.MutateResult{RowsAffected: 1}, nil
+	}
+
 	if op.Type == "copy" {
 		destination, _ := op.Data["destination"].(string)
 		if err := c.copyKey(ctx, op.Object, strings.TrimSpace(destination)); err != nil {
@@ -163,6 +173,48 @@ func (c *RedisConnector) renameKey(ctx context.Context, from, to string) error {
 	}
 	if err := c.client.Rename(ctx, from, to).Err(); err != nil {
 		return normalizeRedisError(err)
+	}
+	return nil
+}
+
+// renameKeyTo renames a key without overwriting anything.
+//
+// RENAMENX, not RENAME: Redis's RENAME silently discards whatever already sits
+// under the target name, and a rename box is exactly where a typo lands on a key
+// that matters. NX also makes the check atomic — testing with EXISTS first would
+// leave a window between the two commands.
+//
+// In cluster mode a key can only be renamed within its own hash slot, and a new
+// name usually hashes somewhere else; Redis answers CROSSSLOT. Since that covers
+// most renames worth making on a cluster, the key is copied to the new slot and
+// the old one dropped, over the same DUMP/RESTORE path duplication uses. Those
+// two steps are not one atomic operation: the copy happens first, so an
+// interruption leaves the original key untouched rather than losing it.
+func (c *RedisConnector) renameKeyTo(ctx context.Context, from, to string) error {
+	if to == "" {
+		return fmt.Errorf("%w: new key name is required", connector.ErrBadRequest)
+	}
+	if to == from {
+		return fmt.Errorf("%w: the new name must differ from the current one", connector.ErrBadRequest)
+	}
+
+	renamed, err := c.client.RenameNX(ctx, from, to).Result()
+	switch {
+	case err == nil && renamed:
+		return nil
+	case err == nil:
+		return fmt.Errorf("%w: key %q already exists", connector.ErrBadRequest, to)
+	case strings.Contains(strings.ToLower(err.Error()), "no such key"):
+		return fmt.Errorf("%w: key %q not found", connector.ErrRelationNotFound, from)
+	case !strings.Contains(strings.ToLower(err.Error()), "crossslot"):
+		return normalizeRedisError(err)
+	}
+
+	if err := c.copyKey(ctx, from, to); err != nil {
+		return err
+	}
+	if err := c.client.Del(ctx, from).Err(); err != nil {
+		return fmt.Errorf("key copied to %q but %q could not be removed: %w", to, from, normalizeRedisError(err))
 	}
 	return nil
 }

--- a/internal/connector/redis/redis.go
+++ b/internal/connector/redis/redis.go
@@ -34,6 +34,7 @@ type redisClient interface {
 	Scan(ctx context.Context, cursor uint64, match string, count int64) *goredis.ScanCmd
 	Exists(ctx context.Context, keys ...string) *goredis.IntCmd
 	Rename(ctx context.Context, key, newKey string) *goredis.StatusCmd
+	RenameNX(ctx context.Context, key, newKey string) *goredis.BoolCmd
 	Expire(ctx context.Context, key string, expiration time.Duration) *goredis.BoolCmd
 	Persist(ctx context.Context, key string) *goredis.BoolCmd
 	HGetAll(ctx context.Context, key string) *goredis.MapStringStringCmd

--- a/internal/connector/redis/redis_test.go
+++ b/internal/connector/redis/redis_test.go
@@ -37,6 +37,10 @@ type fakeRedisClient struct {
 	xRevRangeMessages []goredis.XMessage
 	hscanPairs        []string
 	hlenResult        int64
+	renameNXResult    bool
+	renameNXErr       error
+	renameNXFrom      string
+	renameNXTo        string
 }
 
 type fakeScanClient struct {
@@ -185,6 +189,18 @@ func (f *fakeRedisClient) Exists(context.Context, ...string) *goredis.IntCmd {
 
 func (f *fakeRedisClient) Rename(context.Context, string, string) *goredis.StatusCmd {
 	return goredis.NewStatusResult("OK", nil)
+}
+
+// renameNXResult/renameNXErr let a test stand in for the two answers that decide
+// the rename path: false means the target name is taken, an error carrying
+// CROSSSLOT sends the rename down the copy-and-delete route.
+func (f *fakeRedisClient) RenameNX(_ context.Context, key, newKey string) *goredis.BoolCmd {
+	f.renameNXFrom = key
+	f.renameNXTo = newKey
+	if f.renameNXErr != nil {
+		return goredis.NewBoolResult(false, f.renameNXErr)
+	}
+	return goredis.NewBoolResult(f.renameNXResult, nil)
 }
 
 func (f *fakeRedisClient) Expire(_ context.Context, _ string, expiration time.Duration) *goredis.BoolCmd {

--- a/internal/connector/redis/rename_test.go
+++ b/internal/connector/redis/rename_test.go
@@ -1,0 +1,113 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/zxchlorka/kizuna/internal/connector"
+)
+
+func TestRenameKeyTo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		from       string
+		to         string
+		nxResult   bool
+		nxErr      error
+		doErr      error
+		wantErr    string
+		wantIs     error
+		wantCopied bool
+	}{
+		{
+			name:     "renames within a slot",
+			from:     "profile:1",
+			to:       "profile:2",
+			nxResult: true,
+		},
+		{
+			name:     "refuses to overwrite an existing key",
+			from:     "profile:1",
+			to:       "profile:2",
+			nxResult: false,
+			wantErr:  "already exists",
+			wantIs:   connector.ErrBadRequest,
+		},
+		{
+			name:    "empty target",
+			from:    "profile:1",
+			to:      "",
+			wantErr: "required",
+			wantIs:  connector.ErrBadRequest,
+		},
+		{
+			name:    "same name",
+			from:    "profile:1",
+			to:      "profile:1",
+			wantErr: "must differ",
+			wantIs:  connector.ErrBadRequest,
+		},
+		{
+			name:    "missing source",
+			from:    "gone",
+			to:      "profile:2",
+			nxErr:   errors.New("ERR no such key"),
+			wantErr: "not found",
+			wantIs:  connector.ErrRelationNotFound,
+		},
+		{
+			// The point of the fallback: a cluster refuses a rename across hash
+			// slots, so the key travels by DUMP/RESTORE instead. The copy is
+			// reached here rather than completed — the fake fails the DUMP, and
+			// that error surfacing proves which path was taken.
+			name:       "a cross-slot rename falls back to copying",
+			from:       "profile:1",
+			to:         "other:2",
+			nxErr:      errors.New("CROSSSLOT Keys in request don't hash to the same slot"),
+			doErr:      errors.New("dump refused by the fake"),
+			wantErr:    "dump refused by the fake",
+			wantCopied: true,
+		},
+		{
+			name:    "an unrelated error is reported as itself",
+			from:    "profile:1",
+			to:      "profile:2",
+			nxErr:   errors.New("READONLY You can't write against a read only replica"),
+			wantErr: "READONLY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeRedisClient{renameNXResult: tt.nxResult, renameNXErr: tt.nxErr, doErr: tt.doErr}
+			conn := newTestRedisConnectorWithClient(fake)
+
+			err := conn.renameKeyTo(context.Background(), tt.from, tt.to)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if fake.renameNXFrom != tt.from || fake.renameNXTo != tt.to {
+					t.Fatalf("renamed %q -> %q, want %q -> %q", fake.renameNXFrom, fake.renameNXTo, tt.from, tt.to)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not mention %q", err, tt.wantErr)
+			}
+			if tt.wantIs != nil && !errors.Is(err, tt.wantIs) {
+				t.Fatalf("error %q is not %v", err, tt.wantIs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #31 — merge that one first, this one targets its branch.

Four improvements picked from `docs/ideas/`, the round of UI corrections that
followed, and the v0.8.0 changelog.

## Features

**A link to what is open.** The address bar carried only the connection, so an
investigation could not be handed to anyone. It now carries the object and any
filters applied to it (`?object=public.users&type=table&filter=id.eq.42`), and
opening such a link restores both. Browser Back and Forward walk the objects
visited. The codec drops an unknown object type or a malformed filter rather
than trusting it — a link arrives from someone else's clipboard.

**Rename a Redis key.** The backend could already rename; there was no way to
ask for it. `RENAMENX` is used rather than `RENAME`, which silently discards
whatever sits under the target name — a rename box is exactly where a typo lands
on a key that matters. A cluster refuses a rename across hash slots, so the key
is copied to the new slot and the old one dropped, over the same DUMP/RESTORE
path duplication already uses. Not atomic: the copy runs first, so an
interruption leaves the original intact.

**Search Kafka by key and headers.** Conditions gained a target (payload, key,
header) and a `contains` comparison. Key and header conditions match on records
whose body is binary or never parses as JSON, which no payload path can reach.
The client-side "Filter loaded" predicate mirrors the backend scan case for case
— the two disagreeing has been a real bug here before, so the Go and TypeScript
tests are written as twins.

**Copy a row as SQL.** `SELECT`, `INSERT`, `UPDATE`, `DELETE` for the row in the
card. `UPDATE` and `DELETE` are generated only against a complete primary key;
without one they are not offered.

## Corrections after review

- The Kafka condition row wrapped, which pushed the value input onto a second
  line beside a disabled field box, and the two together read as "type the key
  here". The row is now one line and a key condition has no field box at all.
- The Redis key header lost its labelled buttons: the pencil sits on the name it
  renames, refresh/duplicate/delete are icons with hover labels, Links keeps its
  word. The type/connection/mode panels are gone.
- Connection-wide facts moved to the tab bar: the connection's name and mode, and
  the list of every link on it. An object's own menu is now only about that
  object — the same block is removed from the Postgres table view.
- A link that reads a Redis value can be followed from the value, and the links a
  key can be walked along are shown as chips beneath its name.

## Fixed

The rule deciding whether a filter condition says anything existed twice — once
in the store, once inline in `KafkaMessageBrowser`. Only the first learned about
key conditions, so a key-only filter was dropped before it reached a request:
nothing applied, no badge, and it appeared to start working only once a stale
JSON path from an earlier target made the old rule pass. The copy is deleted.
Clearing a filter now also clears the dialog draft, so the badge goes with it.

## Verification

Go and frontend suites green (381 frontend tests). Beyond that, on the built
image: the reported Kafka sequence reproduced end to end (7/7 — key condition
counted immediately, filters and scans by key, clear restoring every row and
dropping the badge), the Redis key view checked in the browser (13/13 — pencil,
icon buttons, no panels, no connection-wide list in the key menu, chip visible
and navigating, value menu offering the jump), and the deep link verified both
directions including a filtered link opening with its rows narrowed.
